### PR TITLE
Increase max keyrings from 500 to 1000000

### DIFF
--- a/jobs/garden/templates/garden_ctl.erb
+++ b/jobs/garden/templates/garden_ctl.erb
@@ -115,8 +115,8 @@ case $1 in
     create_loop_devices 256
     setup_apparmor
 
-    echo 500 > /proc/sys/kernel/keys/maxkeys
-    echo 500 > /proc/sys/kernel/keys/root_maxkeys
+    echo 1000000 > /proc/sys/kernel/keys/maxkeys
+    echo 1000000 > /proc/sys/kernel/keys/root_maxkeys
 
     echo 1 > /proc/sys/kernel/dmesg_restrict
 


### PR DESCRIPTION
- Fixes the following issue `runc create: exit status 1: could not
  create session key: disk quota exceeded` that occurs when a lot of
  containers are created simultaneously

Related Slack context/discussion: https://cloudfoundry.slack.com/archives/garden/p1468012069004093

Screenshot of keyring limit issue that this PR fixes:
![screen shot 2016-08-05 at 12 11 50 pm](https://cloud.githubusercontent.com/assets/1504464/17442887/e5bcb6cc-5b05-11e6-8ce4-f164ed71a015.png)

We've been running our Buildpacks team Concourse deployment with this fix applied for ~3 weeks now and it's been stable/we haven't seen the issue reappear.
