### PR TITLE
Add `oci_image_binary` property to guardian job

### DIFF
--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -116,3 +116,7 @@ properties:
   garden.apparmor_profile:
     decription: Apparmor profile to use for unprivileged container procesess
     default: garden-default
+
+  garden.experimental_oci_image_binary:
+    description: The grootfs binary path
+    default: /var/vcap/packages/grootfs/grootfs

--- a/jobs/garden/templates/garden_ctl.erb
+++ b/jobs/garden/templates/garden_ctl.erb
@@ -138,6 +138,7 @@ case $1 in
       --iptables-bin=/var/vcap/packages/iptables/sbin/iptables \
       --init-bin=/var/vcap/packages/guardian/bin/init \
       --dadoo-bin=/var/vcap/packages/guardian/bin/dadoo \
+      --oci-image-bin=<%= p("garden.experimental_oci_image_binary") %> \
       --nstar-bin=/var/vcap/packages/guardian/bin/nstar \
       --tar-bin=/var/vcap/packages/tar/tar \
       --log-level=<%= p("garden.log_level") %> \


### PR DESCRIPTION
Experimental, to be used with `grootfs` only.

🌳 
[#128565533]

Signed-off-by: Tiago Scolari <tscolari@pivotal.io>