### PR TITLE
Implement logic to send service logs to syslog

### DIFF
--- a/jobs/garden/templates/garden_ctl.erb
+++ b/jobs/garden/templates/garden_ctl.erb
@@ -123,6 +123,9 @@ case $1 in
 
     ulimit -n 65536
 
+    exec 1> >( tee -a $LOG_DIR/garden.stdout.log | logger -p user.info -t vcap.garden ) \
+         2> >( tee -a $LOG_DIR/garden.stderr.log | logger -p user.error -t vcap.garden )
+
     exec /var/vcap/packages/guardian/bin/the-secret-garden $DATA_DIR $real_graph $graph_path $PIDFILE /var/vcap/packages/guardian/bin/guardian \
     <% if p("garden.listen_network") == "tcp" %> \
     <% ip, port = p("garden.listen_address").split(":") %> \
@@ -196,10 +199,7 @@ case $1 in
     <% end %> \
     <% if_p("garden.apparmor_profile") do |apparmor_profile| %> \
       --apparmor=<%= apparmor_profile %> \
-    <% end %> \
-      1>>$LOG_DIR/garden.stdout.log \
-      2>>$LOG_DIR/garden.stderr.log
-
+    <% end %>
     ;;
 
   stop)


### PR DESCRIPTION
# Motivation

Several of the CF and Diego platform services send logs to the local syslog, tagged as `vcap.*`. . The [metron agent from loggregrator configures the local syslog to send the logs to metron](https://github.com/cloudfoundry/loggregator/blob/develop/jobs/metron_agent/spec#L29) so that later can be sent to a centralised logging service. 

In some cases it is the service application itself who sends the logs to syslog, but it seems to be a common pattern across CF and Diego services to [let the service log to stdout/stderr, and redirect that output to local files or syslog](https://github.com/cloudfoundry/diego-release/blob/develop/jobs/bbs/templates/bbs_as_vcap.erb#L91) using the [`logger` command](http://linux.die.net/man/1/logger). 

Not all the services implement this feature, and instead they only log to local files. In order to centralise all the logs, so we will add the logic required to send the logs of the missing services. 

We will implement the *log to stdout and redirect  to `logger` pattern* whenever is possible.

## Implementation in garden-linux release

~~We add a property `garden.log_to_syslog`. When true,~~ we redirect the stdout and stderr in the ctl script into syslog following the standard vcap pattern, in addition to files.

The logs from garden are already in json parseable format and redirected to log files. We only add the additional code to redirect to `logger`

## How to review? 

~~Enable the `garden.log_to_syslog` and~~ deploy. Logs should be sent to syslog. If metron agent is installed locally, the logs will be redirected to metron agent the loggregrator.

## Open questions

This PR is open to debate with several open questions:

 * Is OK to add a specific property to enable nats logs to syslog? or should this be enabled by default?
 * shall we spawn `logger` and `tee` with the vcap user [as they do in diego?](https://github.com/cloudfoundry/diego-release/blob/develop/jobs/bbs/templates/bbs_as_vcap.erb)
