### PR TITLE
Add apparmor package to garden job and create /sys/kernel/security folder if it is necessary

### DIFF
--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -9,6 +9,7 @@ packages:
   - guardian
   - iptables
   - runc
+  - apparmor
   - shadow
   - busybox
   - tar

--- a/jobs/garden/templates/garden_ctl.erb
+++ b/jobs/garden/templates/garden_ctl.erb
@@ -68,6 +68,7 @@ function setup_apparmor() {
   CONFIG_DIR=/var/vcap/jobs/garden/config
 
   if ! mountpoint -q /sys/kernel/security; then
+    mkdir -p /sys/kernel/security
     mount -t securityfs securityfs /sys/kernel/security
   fi
 


### PR DESCRIPTION
Hey, all!

Today I wanted to run `garden-runc-release 0.8.0`  on `bosh-lite 9000.131.0` and I've noticed several issues that prevent garden job running.

Here is a debug log of `garden_ctl` that shows that `readlink -nf /var/vcap/packages/apparmor/bin` returns empty string and `/sys/kernel/security` mount doesn't exist:
```
...
mknod: ‘/dev/loop253’: File exists
+ true
+ for i in '$(seq 0 $amt)'
+ mknod -m 0660 /dev/loop254 b 7 254
mknod: ‘/dev/loop254’: File exists
+ true
+ for i in '$(seq 0 $amt)'
+ mknod -m 0660 /dev/loop255 b 7 255
mknod: ‘/dev/loop255’: File exists
+ true
+ for i in '$(seq 0 $amt)'
+ mknod -m 0660 /dev/loop256 b 7 256
mknod: ‘/dev/loop256’: File exists
+ true
+ setup_apparmor
++ readlink -nf /var/vcap/packages/apparmor/bin
+ export PATH=/var/vcap/packages/runc/bin:/var/vcap/packages/shadow/sbin:/var/vcap/packages/iptables/sbin:/var/vcap/bosh/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:
+ PATH=/var/vcap/packages/runc/bin:/var/vcap/packages/shadow/sbin:/var/vcap/packages/iptables/sbin:/var/vcap/bosh/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:
+ POLICY=garden-default
+ CONFIG_DIR=/var/vcap/jobs/garden/config
+ mountpoint -q /sys/kernel/security
+ mount -t securityfs securityfs /sys/kernel/security
mount: mount point /sys/kernel/security does not exist
```

This PR helped me to run garden-runc on bosh-lite. 