### PR TITLE
Provide mechanism to opt-out of app armor

### DIFF
--- a/jobs/garden/templates/garden_ctl.erb
+++ b/jobs/garden/templates/garden_ctl.erb
@@ -64,15 +64,17 @@ function create_loop_devices() {
 
 function setup_apparmor() {
   export PATH=$PATH:$(readlink -nf /var/vcap/packages/apparmor/bin)
-  POLICY=garden-default
+  POLICY=<%= p("garden.apparmor_profile") %>
   CONFIG_DIR=/var/vcap/jobs/garden/config
 
   if ! mountpoint -q /sys/kernel/security; then
     mount -t securityfs securityfs /sys/kernel/security
   fi
 
-  if ! aa-status | grep $POLICY > /dev/null; then
-    apparmor_parser -a $CONFIG_DIR/$POLICY
+  if [ -n "$POLICY" ]; then
+    if ! aa-status | grep $POLICY > /dev/null; then
+        apparmor_parser -a $CONFIG_DIR/$POLICY
+    fi
   fi
 }
 
@@ -217,8 +219,8 @@ case $1 in
     <% p("garden.dns_servers").each do |server| %> \
       --dns-server=<%= server %> \
     <% end %> \
-    <% if_p("garden.apparmor_profile") do |apparmor_profile| %> \
-      --apparmor=<%= apparmor_profile %> \
+    <% unless p("garden.apparmor_profile").to_s.empty?  %> \
+      --apparmor=<%= p("garden.apparmor_profile") %> \
     <% end %>
     ;;
 


### PR DESCRIPTION
I'm attempting to use garden-runc in an environment that does not have app armor enabled.  This change allows deployments to explicitly set garden.apparmor_profile to an empty string so garden-runc does not attempt activate the app armor policy paths. By default, the app armor policy is still used.

> Note: Regardless of these changes, the job spec allows users to change the policy name but the start script hard-coded `garden-default`. It's also strange that the policy is a release template but there's no way to customize it. A nice feature would be to provide a mechanism for deployments to include a custom policy definition.