### PR TITLE
default grace time to indefinite

### DIFF
--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -53,7 +53,7 @@ properties:
 
   garden.default_container_grace_time:
     description: "duration after which to reap idle containers"
-    default: 5m
+    default: 0
 
   garden.default_container_rootfs:
     description: "path to the rootfs to use when a container specifies no rootfs"


### PR DESCRIPTION
Reasoning included in commit message.

Note: with this change, Diego can probably stop configuring this in their manifest. This change is also needed for Concourse's new container/volume lifecycle where we no longer heartbeat with GraceTime and instead have an explicit GC.

Alternatively we could remove this property? That would mean `0` means indefinite. Or we could keep it and make the `GraceTime` field a pointer, where `nil` would mean "server default" and `0` would mean "indefinite". (Or some other approach to add the distinction.)