### PR TITLE
Add configuration for an image plugin in garden-windows

### DIFF
--- a/jobs/garden-windows/spec
+++ b/jobs/garden-windows/spec
@@ -14,3 +14,6 @@ properties:
 
   garden.runtime_plugin:
     description: "Path to a runtime plugin binary"
+
+  garden.image_plugin:
+    description: "Path to an image plugin binary"

--- a/jobs/garden-windows/templates/garden_ctl.ps1.erb
+++ b/jobs/garden-windows/templates/garden_ctl.ps1.erb
@@ -1,10 +1,10 @@
-New-Item C:\var\vcap\data\garden\depot -ItemType Directory -Force
+﻿New-Item C:\var\vcap\data\garden\depot -ItemType Directory -Force
 
 C:\var\vcap\packages\guardian-windows\gdn.exe `
   server `
   --skip-setup `
   --runtime-plugin=<%= p("garden.runtime_plugin") %> `
-  --image-plugin=C:\var\vcap\packages\guardian-windows\noop_plugin.exe `
+  --image-plugin=<%= p("garden.image_plugin") %> `
   --network-plugin=C:\var\vcap\packages\guardian-windows\noop_plugin.exe `
   <% ip, port = p("garden.listen_address").split(":") %> `
   --bind-ip=<%= ip %> `


### PR DESCRIPTION
This allows us to use a custom image plugin which works on windows.

@sesmith177 @mdelillo