### PR TITLE
add --tar-bin flag to garden-windows gdn args

### DIFF
--- a/jobs/garden-windows/spec
+++ b/jobs/garden-windows/spec
@@ -24,3 +24,7 @@ properties:
   garden.tar_bin:
     description: "Path to tar binary"
     default: "C:\\var\\vcap\\bosh\\bin\\tar.exe"
+
+  garden.max_containers:
+    description: "Maximum container capacity to advertise. It is not recommended to set this larger than 75."
+    default: 75

--- a/jobs/garden-windows/spec
+++ b/jobs/garden-windows/spec
@@ -17,3 +17,10 @@ properties:
 
   garden.image_plugin:
     description: "Path to an image plugin binary"
+
+  garden.nstar_bin:
+    description: "Path to nstar binary"
+
+  garden.tar_bin:
+    description: "Path to tar binary"
+    default: "C:\\var\\vcap\\bosh\\bin\\tar.exe"

--- a/jobs/garden-windows/templates/garden_ctl.ps1.erb
+++ b/jobs/garden-windows/templates/garden_ctl.ps1.erb
@@ -9,4 +9,6 @@ C:\var\vcap\packages\guardian-windows\gdn.exe `
   <% ip, port = p("garden.listen_address").split(":") %> `
   --bind-ip=<%= ip %> `
   --bind-port=<%= port %> `
+  --nstar-bin=<%= p("garden.nstar_bin") %> `
+  --tar-bin=<%= p("garden.tar_bin") %> `
   --depot C:\var\vcap\data\garden\depot

--- a/jobs/garden-windows/templates/garden_ctl.ps1.erb
+++ b/jobs/garden-windows/templates/garden_ctl.ps1.erb
@@ -11,4 +11,5 @@ C:\var\vcap\packages\guardian-windows\gdn.exe `
   --bind-port=<%= port %> `
   --nstar-bin=<%= p("garden.nstar_bin") %> `
   --tar-bin=<%= p("garden.tar_bin") %> `
+  --max-containers=<%= p("garden.max_containers") %> `
   --depot C:\var\vcap\data\garden\depot


### PR DESCRIPTION
- to support stream in/out
- the provided path is the default path for tar on the Windows stemcell

[#146150119]