### PR TITLE
Add destroy_containers_on_start property to garden-windows

### DIFF
--- a/jobs/garden-windows/spec
+++ b/jobs/garden-windows/spec
@@ -28,3 +28,7 @@ properties:
   garden.max_containers:
     description: "Maximum container capacity to advertise. It is not recommended to set this larger than 75."
     default: 75
+
+  garden.destroy_containers_on_start:
+    description: "If true, all existing containers will be destroyed any time the garden server starts up"
+    default: false

--- a/jobs/garden-windows/templates/garden_ctl.ps1.erb
+++ b/jobs/garden-windows/templates/garden_ctl.ps1.erb
@@ -12,4 +12,7 @@ C:\var\vcap\packages\guardian-windows\gdn.exe `
   --nstar-bin=<%= p("garden.nstar_bin") %> `
   --tar-bin=<%= p("garden.tar_bin") %> `
   --max-containers=<%= p("garden.max_containers") %> `
+  <% if p("garden.destroy_containers_on_start") %> `
+  --destroy-containers-on-startup `
+  <% end %> `
   --depot C:\var\vcap\data\garden\depot


### PR DESCRIPTION
This allows a diego cell with garden-windows to be redeployed by BOSH

[#148146569]

Signed-off-by: Sam Smith <sesmith177@gmail.com>