### PR TITLE
Don't setup apparmor if no profile is provided

### DIFF
--- a/jobs/garden/templates/garden_ctl.erb
+++ b/jobs/garden/templates/garden_ctl.erb
@@ -171,7 +171,11 @@ case $1 in
 
     permit_device_control
     create_loop_devices 256
-    setup_apparmor
+    
+    <% if !p("garden.apparmor_profile").empty?  %>
+      setup_apparmor
+    <% end %>
+
     set_graph_permissions "$graph_path"
 
     echo 1 > /proc/sys/kernel/dmesg_restrict


### PR DESCRIPTION
Seems like passing "" to that property is supposed to not use apparmor, so don't bother setting it up.