### PR TITLE
add default container rootfs for windows job

### DIFF
--- a/jobs/garden-windows/spec
+++ b/jobs/garden-windows/spec
@@ -12,6 +12,10 @@ properties:
     description: "Garden server listening address."
     default: 127.0.0.1:7777
 
+  garden.log_level:
+    description: "log level for the Garden server - can be debug, info, error or fatal"
+    default: info
+
   garden.runtime_plugin:
     description: "Path to a runtime plugin binary"
 
@@ -35,3 +39,7 @@ properties:
   garden.destroy_containers_on_start:
     description: "If true, all existing containers will be destroyed any time the garden server starts up"
     default: false
+
+  garden.default_container_rootfs:
+    description: "path to the rootfs to use when a container specifies no rootfs"
+    default: ""

--- a/jobs/garden-windows/templates/garden_ctl.ps1.erb
+++ b/jobs/garden-windows/templates/garden_ctl.ps1.erb
@@ -1,22 +1,32 @@
-﻿New-Item C:\var\vcap\data\garden\depot -ItemType Directory -Force
+﻿$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
 
-$imageStore="C:\var\vcap\winc-image\store"
+$gardenDir="C:\var\vcap\data\garden"
+$depotDir=(Join-Path $gardenDir "depot")
+$imageStore=(Join-Path $gardenDir "image-store")
+
+New-Item $depotDir -ItemType Directory -Force
+New-Item $imageStore -ItemType Directory -Force
 
 C:\var\vcap\packages\guardian-windows\gdn.exe `
   server `
   --skip-setup `
-  --runtime-plugin=<%= p("garden.runtime_plugin") %> `
-  --image-plugin=<%= p("garden.image_plugin") %> `
-  --image-plugin-extra-arg=--store=$imageStore `
-  --network-plugin=<%= p("garden.network_plugin") %> `
+  --depot=$depotDir `
+  --log-level=<%= p("garden.log_level") %> `
   <% ip, port = p("garden.listen_address").split(":") %> `
   --bind-ip=<%= ip %> `
   --bind-port=<%= port %> `
+  --max-containers=<%= p("garden.max_containers") %> `
+  <% if !p("garden.default_container_rootfs").empty? %> `
+  --default-rootfs=<%= p("garden.default_container_rootfs") %> `
+  <% end %> `
+  --runtime-plugin=<%= p("garden.runtime_plugin") %> `
+  --runc-root=$imageStore `
+  --image-plugin=<%= p("garden.image_plugin") %> `
+  --image-plugin-extra-arg=--store=$imageStore `
+  --network-plugin=<%= p("garden.network_plugin") %> `
   --nstar-bin=<%= p("garden.nstar_bin") %> `
   --tar-bin=<%= p("garden.tar_bin") %> `
-  --max-containers=<%= p("garden.max_containers") %> `
   <% if p("garden.destroy_containers_on_start") %> `
   --destroy-containers-on-startup `
-  --runc-root=$imageStore `
-  <% end %> `
-  --depot C:\var\vcap\data\garden\depot
+  <% end %>


### PR DESCRIPTION
also adds:
- powershell exception handling
- cleaner directory/path creation
- log level configuration
- `--runc-root` flag was incorrectly nested inside of `destroy-containers-on-startup` if block