### PR TITLE
add extra network plugin args property to garden-windows

### DIFF
--- a/jobs/garden-windows/spec
+++ b/jobs/garden-windows/spec
@@ -25,6 +25,10 @@ properties:
   garden.network_plugin:
     description: "Path to a network plugin binary"
 
+  garden.network_plugin_extra_args:
+    description: "An array of additional arguments which will be passed to the network plugin binary"
+    default: []
+
   garden.nstar_bin:
     description: "Path to nstar binary"
 

--- a/jobs/garden-windows/templates/garden_ctl.ps1.erb
+++ b/jobs/garden-windows/templates/garden_ctl.ps1.erb
@@ -25,6 +25,9 @@ C:\var\vcap\packages\guardian-windows\gdn.exe `
   --image-plugin=<%= p("garden.image_plugin") %> `
   --image-plugin-extra-arg=--store=$imageStore `
   --network-plugin=<%= p("garden.network_plugin") %> `
+  <% p("garden.network_plugin_extra_args").each do |arg| %> `
+  --network-plugin-extra-arg=<%= arg %> `
+  <% end %> `
   --nstar-bin=<%= p("garden.nstar_bin") %> `
   --tar-bin=<%= p("garden.tar_bin") %> `
   <% if p("garden.destroy_containers_on_start") %> `


### PR DESCRIPTION
used for specifying a config file to the network plugin