### PR TITLE
Add property for passing args to runtime plugin

### DIFF
--- a/jobs/garden-windows/spec
+++ b/jobs/garden-windows/spec
@@ -26,6 +26,10 @@ properties:
   garden.runtime_plugin:
     description: "Path to a runtime plugin binary"
 
+  garden.runtime_plugin_extra_args:
+    description: "An array of additional arguments which will be passed to the runtime plugin binary"
+    default: []
+
   garden.image_plugin:
     description: "Path to an image plugin binary"
 

--- a/jobs/garden-windows/templates/garden_ctl.ps1.erb
+++ b/jobs/garden-windows/templates/garden_ctl.ps1.erb
@@ -21,6 +21,9 @@ C:\var\vcap\packages\guardian-windows\gdn.exe `
   --default-rootfs=<%= p("garden.default_container_rootfs") %> `
   <% end %> `
   --runtime-plugin=<%= p("garden.runtime_plugin") %> `
+  <% p("garden.runtime_plugin_extra_args").each do |arg| %> `
+  --runtime-plugin-extra-arg=<%= arg %> `
+  <% end %> `
   --image-plugin=<%= p("garden.image_plugin") %> `
   --image-plugin-extra-arg=--store=$imageStore `
   --network-plugin=<%= p("garden.network_plugin") %> `


### PR DESCRIPTION
Used by `winc` in place of removed `--runc-root` flag. Depends on https://github.com/cloudfoundry/guardian/pull/101.