### PR TITLE
Add image_plugin_extra_args property to garden-windows

### DIFF
--- a/jobs/garden-windows/spec
+++ b/jobs/garden-windows/spec
@@ -33,6 +33,10 @@ properties:
   garden.image_plugin:
     description: "Path to an image plugin binary"
 
+  garden.image_plugin_extra_args:
+    description: "An array of additional arguments which will be passed to the image plugin binary"
+    default: []
+
   garden.network_plugin:
     description: "Path to a network plugin binary"
 

--- a/jobs/garden-windows/templates/garden_ctl.ps1.erb
+++ b/jobs/garden-windows/templates/garden_ctl.ps1.erb
@@ -21,11 +21,15 @@ C:\var\vcap\packages\guardian-windows\gdn.exe `
   --default-rootfs=<%= p("garden.default_container_rootfs") %> `
   <% end %> `
   --runtime-plugin=<%= p("garden.runtime_plugin") %> `
+  --runtime-plugin-extra-arg=--image-store=$imageStore `
   <% p("garden.runtime_plugin_extra_args").each do |arg| %> `
   --runtime-plugin-extra-arg=<%= arg %> `
   <% end %> `
   --image-plugin=<%= p("garden.image_plugin") %> `
   --image-plugin-extra-arg=--store=$imageStore `
+  <% p("garden.image_plugin_extra_args").each do |arg| %> `
+  --image-plugin-extra-arg=<%= arg %> `
+  <% end %> `
   --network-plugin=<%= p("garden.network_plugin") %> `
   <% p("garden.network_plugin_extra_args").each do |arg| %> `
   --network-plugin-extra-arg=<%= arg %> `


### PR DESCRIPTION
Also, ensure --image-store is passed to runtime plugin as an extra arg

This enables adding extra args for image plugin logging, see: https://www.pivotaltracker.com/story/show/152332149