### PR TITLE
add BOSH property to use --additional-host-entry

### DIFF
--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -104,6 +104,10 @@ properties:
     description: "Additional DNS servers to be used in containers; extends those used on the host or those set by dns_servers property"
     default: []
 
+  garden.additional_host_entries:
+    description: ""
+    default: []
+
   garden.insecure_docker_registry_list:
     description: "A list of IP:PORT tuples that we allow pulling docker images from using self-signed certificates."
     default: []

--- a/jobs/garden/templates/bin/garden_start.erb
+++ b/jobs/garden/templates/bin/garden_start.erb
@@ -173,6 +173,9 @@ server --skip-setup \
 <% p("garden.additional_dns_servers").each do |server| %> \
   --additional-dns-server=<%= server %> \
 <% end %> \
+<% p("garden.additional_host_entries").each do |host_entry| %> \
+  --additional-host-entry="<%= host_entry %>" \
+<% end %>
 <% if !p("garden.apparmor_profile").empty? %> \
   --apparmor=<%= p("garden.apparmor_profile") %> \
 <% end %> \


### PR DESCRIPTION
![](https://media1.giphy.com/media/BvBm716X0ldV6/giphy.gif)

Quotes are necessary in the `garden_start.erb` so one can add things like `127.0.0.1	homesweethome`