### PR TITLE
Add log-format configurability to garden-windows

### DIFF
--- a/jobs/garden-windows/spec
+++ b/jobs/garden-windows/spec
@@ -62,3 +62,7 @@ properties:
   garden.default_container_rootfs:
     description: "path to the rootfs to use when a container specifies no rootfs"
     default: ""
+
+  logging.format.timestamp:
+    description: "Format for timestamp in component logs. Valid values are 'unix-epoch' and 'rfc3339'."
+    default: "unix-epoch"

--- a/jobs/garden-windows/templates/garden_ctl.ps1.erb
+++ b/jobs/garden-windows/templates/garden_ctl.ps1.erb
@@ -47,4 +47,10 @@ C:\var\vcap\packages\guardian-windows\gdn.exe `
   <% end %> `
   <% if p("garden.destroy_containers_on_start") %> `
   --destroy-containers-on-startup `
+  <% end %> `
+  <% if_p("logging.format.timestamp") do |format| %> `
+  <% if format != "unix-epoch" and format != "rfc3339" %> `
+    <% raise "logging.format.timestamp should be one of: 'unix-epoch' or 'rfc3339'" %> `
+  <% end %> `
+  --time-format=<%= format %> `
   <% end %>

--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -238,5 +238,5 @@ properties:
     default: false
 
   logging.format.timestamp:
-    description: "EXPERIMENTAL: Format for timestamp in component logs. Valid values are 'unix-epoch' and 'rfc3339'."
+    description: "Format for timestamp in component logs. Valid values are 'unix-epoch' and 'rfc3339'."
     default: "unix-epoch"


### PR DESCRIPTION
Analogue of https://github.com/cloudfoundry/garden-runc-release/pull/78 for the garden-windows job.

Also removes experimental language from corresponding property on the garden job.