### PR TITLE
Ensure the /var/vcap/sys/log/garden dir exists

### DIFF
--- a/jobs/garden/templates/bin/garden_start.erb
+++ b/jobs/garden/templates/bin/garden_start.erb
@@ -6,6 +6,7 @@ source /var/vcap/jobs/garden/bin/envs
 source /var/vcap/packages/greenskeeper/bin/system-preparation
 
 <% if !p("bpm.enabled") %>
+  mkdir -p "${LOG_DIR}"
   exec 1>> "${LOG_DIR}/garden_start.stdout.log"
   exec 2>> "${LOG_DIR}/garden_start.stderr.log"
 

--- a/jobs/garden/templates/bin/garden_start.erb
+++ b/jobs/garden/templates/bin/garden_start.erb
@@ -5,8 +5,15 @@ set -e
 source /var/vcap/jobs/garden/bin/envs
 source /var/vcap/packages/greenskeeper/bin/system-preparation
 
+log "running greenskeeper"
+greenskeeper_cmd="/var/vcap/packages/greenskeeper/bin/greenskeeper"
+<% if p("garden.experimental_rootless_mode") %>
+  greenskeeper_cmd="$greenskeeper_cmd --rootless"
+<% end %>
+$greenskeeper_cmd
+log "running greenskeeper: done"
+
 <% if !p("bpm.enabled") %>
-  mkdir -p "${LOG_DIR}"
   exec 1>> "${LOG_DIR}/garden_start.stdout.log"
   exec 2>> "${LOG_DIR}/garden_start.stderr.log"
 
@@ -27,14 +34,6 @@ increase_max_procs
   load_apparmor_profile "$GARDEN_CONFIG_DIR"/garden-default
 <% end %>
 log "preparing system: done"
-
-log "running greenskeeper"
-greenskeeper_cmd="/var/vcap/packages/greenskeeper/bin/greenskeeper"
-<% if p("garden.experimental_rootless_mode") %>
-  greenskeeper_cmd="$greenskeeper_cmd --rootless"
-<% end %>
-$greenskeeper_cmd
-log "running greenskeeper: done"
 
 # cannot over-write an executable mid-execution
 rm -f "$RUNTIME_BIN_DIR"/init


### PR DESCRIPTION
For the `garden` job, during start time.

Use `mkdir -p` to create the `/var/vcap/sys/log/garden` dir, in case is not there.
It should do nothing, if the dir already exists.