### PR TITLE
allow no-image-plugin to be provided via manifest properties

### DIFF
--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -111,6 +111,10 @@ properties:
     description: "Path to a runtime plugin binary"
     default: /var/vcap/packages/runc/bin/runc
 
+  garden.no_image_plugin:
+    description: "If true, disables image plugin usage, thus ignoring other image plugin settings"
+    default: false
+
   garden.image_plugin:
     description: "Path to an optional image plugin binary"
 

--- a/jobs/garden/templates/config/config.ini.erb
+++ b/jobs/garden/templates/config/config.ini.erb
@@ -57,28 +57,28 @@
 <% if p("garden.no_image_plugin") -%>
   no-image-plugin = true
 <% else -%>
-<% if use_provided_image_plugin -%>
-  image-plugin = <%= image_plugin %>
-  <% p("garden.image_plugin_extra_args").each do |arg| -%>
-  image-plugin-extra-arg = <%= arg %>
+  <% if use_provided_image_plugin -%>
+    image-plugin = <%= image_plugin %>
+    <% p("garden.image_plugin_extra_args").each do |arg| -%>
+    image-plugin-extra-arg = <%= arg %>
+    <% end -%>
   <% end -%>
-<% end -%>
-<% if use_provided_privileged_image_plugin -%>
-  privileged-image-plugin = <%= privileged_image_plugin %>
-  <% p("garden.privileged_image_plugin_extra_args").each do |arg| -%>
-  privileged-image-plugin-extra-arg = <%= arg %>
+  <% if use_provided_privileged_image_plugin -%>
+    privileged-image-plugin = <%= privileged_image_plugin %>
+    <% p("garden.privileged_image_plugin_extra_args").each do |arg| -%>
+    privileged-image-plugin-extra-arg = <%= arg %>
+    <% end -%>
   <% end -%>
-<% end -%>
-<% if use_default_image_plugin -%>
-  image-plugin = /var/vcap/packages/grootfs/bin/grootfs
-  image-plugin-extra-arg = "--config"
-  image-plugin-extra-arg = <%= groot_config_dir %>/grootfs_config.yml
-<% end -%>
-<% if use_default_privileged_image_plugin -%>
-  privileged-image-plugin = /var/vcap/packages/grootfs/bin/grootfs
-  privileged-image-plugin-extra-arg = "--config"
-  privileged-image-plugin-extra-arg = <%= groot_config_dir %>/privileged_grootfs_config.yml
-<% end -%>
+  <% if use_default_image_plugin -%>
+    image-plugin = /var/vcap/packages/grootfs/bin/grootfs
+    image-plugin-extra-arg = "--config"
+    image-plugin-extra-arg = <%= groot_config_dir %>/grootfs_config.yml
+  <% end -%>
+  <% if use_default_privileged_image_plugin -%>
+    privileged-image-plugin = /var/vcap/packages/grootfs/bin/grootfs
+    privileged-image-plugin-extra-arg = "--config"
+    privileged-image-plugin-extra-arg = <%= groot_config_dir %>/privileged_grootfs_config.yml
+  <% end -%>
 <% end -%>
 <% if_p("garden.docker_registry_endpoint") do |endpoint| -%>
   docker-registry = <%= endpoint %>

--- a/jobs/garden/templates/config/config.ini.erb
+++ b/jobs/garden/templates/config/config.ini.erb
@@ -54,6 +54,9 @@
 
 ; image and rootfs
   default-rootfs = <%= p("garden.default_container_rootfs") %>
+<% if p("garden.no_image_plugin") -%>
+  no-image-plugin = true
+<% else -%>
 <% if use_provided_image_plugin -%>
   image-plugin = <%= image_plugin %>
   <% p("garden.image_plugin_extra_args").each do |arg| -%>
@@ -75,6 +78,7 @@
   privileged-image-plugin = /var/vcap/packages/grootfs/bin/grootfs
   privileged-image-plugin-extra-arg = "--config"
   privileged-image-plugin-extra-arg = <%= groot_config_dir %>/privileged_grootfs_config.yml
+<% end -%>
 <% end -%>
 <% if_p("garden.docker_registry_endpoint") do |endpoint| -%>
   docker-registry = <%= endpoint %>


### PR DESCRIPTION
Tested manually in both the positive and the negative against a Concourse deployment.

I tried indenting the conditionals, but then the actual config ended up indented. I had a look for ERB style guides, but didn't find a conclusive answer regarding indentation of nested `if`s. Then I had a flashback of writing PHP and JSP and having to care about such things, broke out in a cold sweat, and then decided it probably doesn't matter too much*.

*_Some of the stories in this comment may not be factually accurate._