### PR TITLE
Add configurable disk reserve for GrootFS

### DIFF
--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -238,6 +238,10 @@ properties:
     description: "Amount of space the GC algorithm should attempt to keep free for other jobs. GC will delete  unneeded layers as needed to keep this space free (but it cannot guarantee this space remains free if more containers are created than disk space allows). -1 disables GC."
     default: 15360
 
+  grootfs.disk_reserved_space_bytes:
+    description: "Amount of disk space (in bytes) that should not be consumed by GrootFS."
+    default: 16106127360
+
   bpm.enabled:
     description: "Use bpm. NOTE: this requires a recreate when enabling for the first time, otherwise old containers may be left running. NOTE: When this property is enabled, containers won't survive a restart of the garden job. This is why garden.destroy_containers_on_start should be set to avoid leaking container state."
     default: false

--- a/jobs/garden/templates/bin/grootfs-utils.erb
+++ b/jobs/garden/templates/bin/grootfs-utils.erb
@@ -26,7 +26,7 @@ volume_size() {
     echo "0"
     return
   fi
-  echo "$(( $(df --output=size  $store_mountpoint | sed 1d) * 1024 ))"
+  echo "$(( $(df --output=size  $store_mountpoint | sed 1d) * 1024 - <%= p('grootfs.disk_reserved_space_bytes') %>))"
 }
 
 function log() {


### PR DESCRIPTION
Currently, the XFS volume is initialised with the size of the entire partition. While the file might not consume this size right from the beginning (it's a sparse file), the actual consumption is subject to the internal allocation behaviour of XFS. Hence, we have no guarantee that XFS will not at some point consume all of that space.

We have observed instances in which the actual size of the volume grew so big that the Diego cell became unusable due to a 100% disk consumption in `/var/vcap/data`.
Applications with an I/O profile that makes heavy use of the R/W layer seem to trigger this problem.

This PR introduces a configurable reserve of disk space that must not be consumed by GrootFS. 
The default value (15gb) is consistent with the threshold defined for `reserved_space_for_other_jobs_in_mb`. The GC overestimates the disk usage by accumulating the committed disk quotas (RW layers) + actual size of re-usable layers. Hence, the GC should still be triggered before the actual disk consumption hits cap-15gb.