### PR TITLE
fix: Use netcat over curl when talking to unix sockets.

### DIFF
--- a/jobs/garden/templates/bin/post-start
+++ b/jobs/garden/templates/bin/post-start
@@ -1,19 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck disable=SC1091
-source /var/vcap/jobs/garden/bin/post-start-env
-curl_args=("${curl_args[@]}")  # ensure curl_args is defined
-
 start="$( date +%s )"
 timeout=120
 
 echo "$(date): Pinging garden server..."
 i=1
 
+<% if p("garden.listen_network") == "tcp" -%>
+cmd='curl -s <%= p("garden.listen_address") %>/ping'
+<% else -%>
+cmd='echo -e "GET /ping HTTP/1.1\r\n\r\n" | nc -U <%= p("garden.listen_address") %>'
+<% end -%>
+
 while [ $(( $(date +%s) - timeout )) -lt "$start" ]; do
   echo "$(date): Attempt $i..."
-  if curl -s "${curl_args[@]}"; then
+  if sh -c "${cmd}"; then
     echo "$(date): Success!"
     exit 0
   fi


### PR DESCRIPTION
Curl's support for unix sockets varies considerably depending on its
version. Netcat's support is more stable.

Origin ticket: https://github.com/cloudfoundry-incubator/kubecf/issues/505 (Links to (semi-)related PRs).
