### PR TITLE
Only killall containerd of the included package.  

### DIFF
--- a/jobs/garden/templates/bin/containerd_utils.erb
+++ b/jobs/garden/templates/bin/containerd_utils.erb
@@ -65,5 +65,5 @@ start_containerd() {
 
 stop_containerd() {
   log "stopping containerd"
-  killall -s SIGKILL containerd
+  killall -s SIGKILL -e /var/vcap/packages/containerd/bin/containerd
 }


### PR DESCRIPTION
We have a use case where we used the https://github.com/cloudfoundry-incubator/docker-boshrelease to have a separate container run in our VM.

This also starts a containerd instance.  The problem is during the stop since garden is doing a killall it killed "ALL" instances on containerd including the one the docker-release started (not from packages).   This caused the docker-boshrelease to have issues trying to stop it's containers.

This change will make sure that garden only tries to stop those containerd instances that it started.