### PR TITLE
Accommodate GCC 10 Changes

### DIFF
--- a/packages/xfs-progs/packaging
+++ b/packages/xfs-progs/packaging
@@ -33,6 +33,8 @@ setDeps(){
 tar xvzf xfs-progs/xfsprogs-4.20.0.tar.gz
 (
   cd xfsprogs-4.20.0
+  # gcc 10+ changed the default to "-fno-common"; we change it back to build properly
+  export CFLAGS="${CFLAGS} -fcommon"
 
   setDeps
 


### PR DESCRIPTION
The newer GCC compiler (10+) has tightened its requirements, throwing errors that were previously ignored. newer stemcells, e.g. the upcoming Ubuntu 22.04 Jammy Jellyfish, include the newer GCC.

This change will allow the Garden-runC release to build on newer stemcells.

From _[Porting to GCC 10](https://gcc.gnu.org/gcc-10/porting_to.html)_

> Default to -fno-common ... In previous GCC versions this error is ignored. GCC 10 defaults to -fno-common, which means a linker error will now be reported

fixes:
```
Task 46850 | 21:35:18 | Compiling packages: xfs-progs/b8baad87ddfdd32b428001fbdf4b2fd4e1bb9a28a4aa196782d3e5f92650d546 (00:07:20)
                     L Error: Action Failed get_task: Task eeebef25-e9be-4d4a-47c2-06905757de07 result: Compiling package xfs-progs: Running packaging script: Running packaging script: Command exited with 2; Truncated stdout: xfsprogs-4.20.0/m4/lt~obsolete.m4
...
/bin/ld: ../libxlog/.libs/libxlog.a(util.o):/var/vcap/data/compile/xfs-progs/xfsprogs-4.20.0/libxlog/util.c:13: multiple definition of `x'; init.o:/var/vcap/data/compile/xfs-progs/xfsprogs-4.20.0/db/init.c:30: first defined here
collect2: error: ld returned 1 exit status
gmake[2]: *** [../include/buildrules:65: xfs_db] Error 1
gmake[1]: *** [include/buildrules:36: db] Error 2
make: *** [Makefile:92: default] Error 2
```

Signed-off-by: Brian Cunnie <bcunnie@vmware.com>
Signed-off-by: Daniel Felipe Ochoa <danielfelipo@vmware.com>
Signed-off-by: Ramon Makkelie <ramonmakkelie@gmail.com>