### PR TITLE
do not allow 0.0.0.0 nework range

### DIFF
--- a/jobs/garden/templates/config/config.ini.erb
+++ b/jobs/garden/templates/config/config.ini.erb
@@ -6,6 +6,7 @@ def parse_ip (ip, var_name)
     ip = ip.split(":")[0]
       begin
         parsed = IPAddr.new ip
+        raise if IPAddr.new('0.0.0.0/24').include? parsed
       rescue  => e
         raise "Invalid #{var_name} '#{ip}': #{e}"
       end

--- a/spec/jobs/garden_spec.rb
+++ b/spec/jobs/garden_spec.rb
@@ -15,7 +15,7 @@ describe 'garden' do
     context 'with defaults' do
       let(:rendered_template) { IniParse.parse(template.render(properties)) }
 
-      it 'binds to a socket' do
+      it 'sets the bind-socket' do
         expect(rendered_template['server']['bind-socket']).to eql('/var/vcap/data/garden/garden.sock')
       end
 
@@ -131,16 +131,29 @@ describe 'garden' do
         expect(rendered_template['server']['bind-port']).to eql(5555)
       end
 
-      # it 'throws an exception if the ip is invalid' do
-      #   properties.merge!({
-      #     'garden' => {
-      #       'listen_network' => 'tcp',
-      #       'listen_address' => '0.0.0.1:5555'
-      #     }
-      #   })
-        
-      #   expect {template.render(properties)}.to raise_error(IPAddr::InvalidAddressError)
-      # end
+      context '(which is invalid)' do
+        it 'throws an exception if the ip is invalid' do
+          properties.merge!({
+            'garden' => {
+              'listen_network' => 'tcp',
+              'listen_address' => '999.999.999.999:5555'
+            }
+          })
+          
+          expect {template.render(properties)}.to raise_error(RuntimeError, /999.999.999.999/)
+        end
+
+        it 'throws an exception if the ip is with 0.x.x.x' do
+          properties.merge!({
+            'garden' => {
+              'listen_network' => 'tcp',
+              'listen_address' => '0.0.0.1:5555'
+            }
+          })
+          
+          expect {template.render(properties)}.to raise_error(RuntimeError, /0.0.0.1/)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
added a check that the user hasn't supplied a 0.0.0.0 network, and a spec for it
also renamed a test to be in-line with others