### PR TITLE
Revert to system iptables for better compatibility

### DIFF
--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -236,7 +236,7 @@ properties:
 
   garden.iptables_bin_dir:
     description: "Path to directory that contains iptables binary"
-    default: /var/vcap/packages/iptables/sbin
+    default: /usr/sbin
 
   grootfs.log_level:
     description: "Log level for grootfs - can be debug, info, error or fatal."


### PR DESCRIPTION
Due to compatibility issues between the bundled version of iptables in
`garden-runc-release` and system-bundled iptables on Xenial and Jammy,
we are migrating away from preferring the bundled version of iptables.

It was provided to ensure compatibility with OSes that bundled versions
of iptables prior to 1.6.x, as garden + silk rely on networking features
from it. However, we do not support any stemcells that old anymore.

If needed, this is still available for overriding, but changing the
default is the easiest way to ensure compatibility between garden/silk
iptables and system iptables functionality.