### PR TITLE
create a job providing garden binaries

### DIFF
--- a/jobs/garden-binaries/spec
+++ b/jobs/garden-binaries/spec
@@ -1,0 +1,22 @@
+---
+name: garden-binaries
+
+templates: {}
+
+packages:
+  - guardian
+  - iptables
+  - containerd
+  - runc
+  - busybox
+  - tar
+  - garden-idmapper
+  - greenskeeper
+  - grootfs
+  - xfs-progs
+  - thresholder
+  - netplugin-shim
+  - dontpanic
+  - tini
+
+properties: {}

--- a/manifests/include-garden-binaries.ops.yml
+++ b/manifests/include-garden-binaries.ops.yml
@@ -1,0 +1,5 @@
+- type: replace
+  path: /instance_groups/name=garden/jobs/-
+  value:
+    name: garden-binaries
+    release: garden-runc


### PR DESCRIPTION
This avoids issues (https://github.com/cloudfoundry/garden-runc-release/issues/233) using `gdn` compiled binaries in BOSH deployments on `jammy` in a way that allows for use in other stemcell lines as well.

By providing the `guardian-binaries` job, other releases can consume `gdn`/`iptables`/`tar`/etc. binaries built on the same stemcell. This will unblock [BOSH deployed Concourse](https://github.com/concourse/concourse-bosh-release) support for Jammy stemcells.

This does not address issues with consuming the `gdn` binary from tagged GitHub releases, which is an issue currently blocking Concourse in containers from supporting `jammy` and `bionic` fully.

@anEXPer @xtremerui