### PR TITLE
GA CPU throttling

### DIFF
--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -222,17 +222,36 @@ properties:
   garden.tcp_retries2:
     description: Sets the `net.ipv4.tcp_retries2` kernel parameter in containers. If not specified, the value from the linux init_net namespace is used.
 
-  garden.experimental_cpu_throttling:
-    description: "Throttle cpu of badly behaving apps. Note this changes the cpu cgroup structure, and existing containers should be destroyed when changing this value (e.g. set destroy_containers_on_start to true)."
-    default: false
-
   garden.experimental_use_containerd_mode_for_processes:
     description: "(Under development) Use containerd for container process management. Must be used with containerd_mode also set to true. NOTE: cannot be used in combination with bpm or rootless"
     default: false
 
+  garden.experimental_cpu_throttling:
+    description: |
+      Deprecated. Will be removed in favor of the non-experimental property.
+      Throttle cpu of badly behaving apps. Note this changes the cpu cgroup
+      structure, and existing containers should be destroyed when changing this
+      value (e.g. set destroy_containers_on_start to true). The non-experimental
+      property will override this one if set.
+    default: false
+
   garden.experimental_cpu_throttling_check_interval:
-    description: "(Under development) Number of seconds between each CPU throttling check"
+    description: |
+      Deprecated. Will be removed in favor of the non-experimental property.
+      Number of seconds between each CPU throttling check. The non-experimental
+      property will override this one if it is set.
     default: 15
+
+  garden.cpu_throttling:
+    description: |
+      Throttle cpu of badly behaving apps. Note this changes the cpu cgroup
+      structure, and existing containers should be destroyed when changing this
+      value (e.g. set destroy_containers_on_start to true).
+
+  garden.cpu_throttling_check_interval:
+    description: |
+      Number of seconds between each CPU throttling check. If set this will
+      override the experimental value.
 
   garden.iptables_bin_dir:
     description: "Path to directory that contains iptables binary"

--- a/jobs/garden/templates/config/config.ini.erb
+++ b/jobs/garden/templates/config/config.ini.erb
@@ -32,6 +32,15 @@ parse_ip(p('garden.network_pool'), 'garden.network_pool')
 -%>
 
 <%
+    def override_if_present(override, fallback)
+      if_p(override) do |prop|
+        return { key: override, value: prop }
+      end
+      return { key: fallback, value: p(fallback) }
+    end
+-%>
+
+<%
     runtime_bin_dir  = "/var/vcap/data/garden/bin"
     rootless         = p("garden.experimental_rootless_mode")
     groot_config_dir = rootless ? "/var/vcap/data/garden/config" : "/var/vcap/jobs/garden/config"
@@ -198,15 +207,12 @@ parse_ip(p('garden.network_pool'), 'garden.network_pool')
 <% if_p("garden.experimental_cpu_entitlement_per_share_in_percent") do |entitlement_per_share| -%>
   cpu-entitlement-per-share = <%= entitlement_per_share %>
 <% end -%>
-<% if_p("garden.experimental_cpu_throttling") do |enable_cpu_throttling| -%>
-  enable-cpu-throttling = <%= enable_cpu_throttling %>
+  enable-cpu-throttling = <%= override_if_present("garden.cpu_throttling", "garden.experimental_cpu_throttling")[:value] %>
+<% cpu_throttling_interval = override_if_present("garden.cpu_throttling_check_interval", "garden.experimental_cpu_throttling_check_interval") -%>
+<% if cpu_throttling_interval[:value] <= 0 -%>
+  <% raise "#{cpu_throttling_interval[:key]} should be a positive integer" -%>
 <% end -%>
-<% if_p("garden.experimental_cpu_throttling_check_interval") do |interval| -%>
-  <% if interval <= 0 -%>
-    <% raise "experimental_cpu_throttling_check_interval should be a positive integer" -%>
-  <% end -%>
-  cpu-throttling-check-interval = <%= interval %>
-<% end -%>
+  cpu-throttling-check-interval = <%= cpu_throttling_interval[:value] %>
 <% if p("garden.disable_swap_limit") -%>
   disable-swap-limit = true
 <% end -%>


### PR DESCRIPTION
### this includes
* adding non-experimental properties for the two cpu throttling properties.
* if the non-experimental properties are present, they take precedent over the experimental ones.
* we should clean up the experimental properties later, but I think allowing some overlap will make migration easier.

### to test
` ./scripts/template-tests`