### PR TITLE
Update garden/grootfs startup to be compatible with bpm > 1.1.9

### DIFF
--- a/jobs/garden/templates/bin/garden_start.erb
+++ b/jobs/garden/templates/bin/garden_start.erb
@@ -23,6 +23,7 @@ disable_transparent_hugepages
 restrict_dmesg_access
 increase_max_open_fds
 increase_max_procs
+permit_device_control
 <% if p("garden.apparmor_profile") == "garden-default" %>
   load_apparmor_profile "$GARDEN_CONFIG_DIR"/garden-default
 <% end %>


### PR DESCRIPTION
Changes to the underlying runc libraries used in BPM changed the permissions of device control, requiring garden to explicitly set them at startup within BPM.

When not run inside a container, the `permit_device_control` function exits without making any changes. As such this should be safe to run as part of the startup script.