### PR TITLE
Bring back xfsprogs

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -42,3 +42,15 @@ tini/tini-v0.18.0.tar.gz:
   size: 32152
   object_id: bfcc2f24-1cf0-432a-67cc-2c19518c839b
   sha: 27b7529ae87ea688e21d0a061b6d9299ff9362f6
+util-linux/util-linux-2.28.tar.gz:
+  size: 8860808
+  object_id: ed756d6a-13d9-475e-6bba-99fc7531b470
+  sha: ad8f1a338c23bcf3519b856295fbdb6a820db64c
+xfs-progs/xfsprogs-4.20.0.tar.gz:
+  size: 1750213
+  object_id: 46a0233d-1423-46d8-49ad-b5d0f07a39aa
+  sha: 46c23a0e222a3374d9c739b8c44be879712e6e75
+zlib/zlib-1.2.11.tar.gz:
+  size: 607698
+  object_id: 34c42971-0f0e-4704-7530-432d180753af
+  sha: e6d119755acdf9104d7ba236b1242696940ed6dd

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,6 +2,14 @@ apparmor/apparmor-2.13.2.tar.gz:
   size: 7369240
   object_id: 3baa1660-b997-47b5-4fad-336937db42b0
   sha: e3ba457792f42178be5cd18192dc1af53e336503
+autoconf/autoconf-2.69.tar.gz:
+  size: 1927468
+  object_id: c2a13621-9ec0-4da4-7ce7-229066284651
+  sha: 562471cbcb0dd0fa42a76665acf0dbb68479b78a
+automake/automake-1.16.1.tar.gz:
+  size: 2300906
+  object_id: fc6c6d98-9fc9-4014-46c5-ea6a7c2028cd
+  sha: sha256:608a97523f97db32f1f5d5615c98ca69326ced2054c9f82e65bade7fc4c9dea8
 busybox/busybox-1.35.0.tar.gz:
   size: 749316
   object_id: b8960a6f-5f3d-4527-690b-692d59d28159
@@ -26,6 +34,14 @@ libseccomp/libseccomp-2.5.1.tar.gz:
   size: 638811
   object_id: 15ec2e2a-4040-43be-7ad9-f6313dc28230
   sha: sha256:ee307e383c77aa7995abc5ada544d51c9723ae399768a97667d4cdb3c3a30d55
+libtool/libtool-2.4.6.tar.gz:
+  size: 1806697
+  object_id: ddac6c73-578e-4b7d-7ce4-807f46661e85
+  sha: 25b6931265230a06f0fc2146df64c04e5ae6ec33
+lzo/lzo-2.09.tar.gz:
+  size: 594855
+  object_id: 39bb6d9a-e168-4137-7751-c8262b743f1d
+  sha: e2a60aca818836181e7e6f8c4f2c323aca6ac057
 musl/musl-1.2.3.tar.gz:
   size: 1058642
   object_id: 0e2e1101-d964-41d5-7c45-9383d0f9ae98

--- a/jobs/garden-binaries/spec
+++ b/jobs/garden-binaries/spec
@@ -13,6 +13,7 @@ packages:
   - garden-idmapper
   - greenskeeper
   - grootfs
+  - xfs-progs
   - thresholder
   - netplugin-shim
   - dontpanic

--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -35,6 +35,7 @@ packages:
   - garden-idmapper
   - greenskeeper
   - grootfs
+  - xfs-progs
   - thresholder
   - netplugin-shim
   - dontpanic

--- a/jobs/garden/templates/bin/overlay-xfs-setup
+++ b/jobs/garden/templates/bin/overlay-xfs-setup
@@ -9,7 +9,7 @@ main() {
   source /var/vcap/jobs/garden/bin/grootfs-utils
   store_mountpoint=${store_mountpoint:?}
 
-  export PATH=/var/vcap/packages/grootfs/bin:$PATH
+  export PATH=/var/vcap/packages/grootfs/bin:/var/vcap/packages/xfs-progs/sbin:$PATH
 
   init_unprivileged_store
   init_privileged_store

--- a/packages/autoconf/packaging
+++ b/packages/autoconf/packaging
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="2.69"
+
+tar xzf "autoconf/autoconf-${version}.tar.gz"
+
+cd "autoconf-${version}"
+
+autoconf_dir="${BOSH_INSTALL_TARGET}/share/autoconf" ./configure "--prefix=${BOSH_INSTALL_TARGET}"
+make
+make install "prefix=${BOSH_INSTALL_TARGET}"

--- a/packages/autoconf/spec
+++ b/packages/autoconf/spec
@@ -1,0 +1,7 @@
+---
+name: autoconf
+
+dependencies: []
+
+files:
+- autoconf/autoconf-2.69.tar.gz

--- a/packages/automake/packaging
+++ b/packages/automake/packaging
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="1.16.1"
+export PATH="/var/vcap/packages/autoconf/bin:${PATH}"
+
+tar xzf "automake/automake-${version}.tar.gz"
+
+cd "automake-${version}"
+
+./configure "--prefix=${BOSH_INSTALL_TARGET}"
+make
+make install "prefix=${BOSH_INSTALL_TARGET}"

--- a/packages/automake/spec
+++ b/packages/automake/spec
@@ -1,0 +1,8 @@
+---
+name: automake
+
+dependencies:
+- autoconf
+
+files:
+- automake/automake-1.16.1.tar.gz

--- a/packages/libtool/packaging
+++ b/packages/libtool/packaging
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="2.4.6"
+
+tar xzf "libtool/libtool-${version}.tar.gz"
+
+cd "libtool-${version}"
+
+./configure "--prefix=${BOSH_INSTALL_TARGET}"
+make
+make install "prefix=${BOSH_INSTALL_TARGET}"

--- a/packages/libtool/spec
+++ b/packages/libtool/spec
@@ -1,0 +1,8 @@
+---
+name: libtool
+
+dependencies: []
+
+files:
+- libtool/libtool-2.4.6.tar.gz
+

--- a/packages/lzo/packaging
+++ b/packages/lzo/packaging
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="2.09"
+
+tar xvzf "lzo/lzo-${version}.tar.gz"
+
+cd "lzo-${version}"
+
+./configure "--prefix=${BOSH_INSTALL_TARGET}"
+make
+make install "prefix=${BOSH_INSTALL_TARGET}"

--- a/packages/lzo/spec
+++ b/packages/lzo/spec
@@ -1,0 +1,11 @@
+---
+name: lzo
+
+dependencies:
+- autoconf
+- automake
+- libtool
+- pkg-config
+
+files:
+- lzo/lzo-2.09.tar.gz

--- a/packages/util-linux/packaging
+++ b/packages/util-linux/packaging
@@ -1,0 +1,27 @@
+# abort script on any command that exits with a non zero value
+set -e
+
+export PACKAGES=/var/vcap/packages
+export PATH=$PACKAGES/util-linux/bin:$PATH
+
+addBuildTool(){
+  export PATH=$PACKAGES/$1/bin:$PATH
+}
+
+setDeps() {
+  addBuildTool libtool
+  addBuildTool automake
+  addBuildTool pkg-config
+  addBuildTool autoconf
+  export AL_OPTS="-I/${PACKAGES}/pkg-config/share/aclocal"
+}
+
+tar xvzf util-linux/util-linux-2.28.tar.gz
+(
+  cd util-linux-2.28
+
+  setDeps
+  ./configure --prefix=$BOSH_INSTALL_TARGET
+  make
+  make install prefix=$BOSH_INSTALL_TARGET
+)

--- a/packages/util-linux/spec
+++ b/packages/util-linux/spec
@@ -1,0 +1,11 @@
+---
+name: util-linux
+
+dependencies:
+- autoconf
+- automake
+- libtool
+- pkg-config
+
+files:
+- util-linux/util-linux-2.28.tar.gz

--- a/packages/xfs-progs/packaging
+++ b/packages/xfs-progs/packaging
@@ -1,0 +1,42 @@
+# abort script on any command that exits with a non zero value
+
+set -e
+
+export PACKAGES=/var/vcap/packages
+
+addBuildTool(){
+  export PATH=$PACKAGES/$1/bin:$PATH
+  export AL_OPTS="${AL_OPTS} -I${PACKAGES}/$1"
+}
+
+addLib(){
+  export PATH=$PACKAGES/$1/bin:$PATH
+  export PKG_CONFIG_PATH="${PACKAGES}/$1/lib/pkgconfig:${PKG_CONFIG_PATH}"
+  export LDFLAGS="${LDFLAGS} -L${PACKAGES}/$1/lib"
+  export CFLAGS="${CFLAGS} -fcommon -I${PACKAGES}/$1/include"
+}
+
+setDeps(){
+  addBuildTool autoconf
+  addBuildTool automake
+  addBuildTool libtool
+  addBuildTool pkg-config
+
+  addLib zlib
+  addLib util-linux
+  addLib lzo
+
+  export CFLAGS="${CFLAGS} -L${PACKAGES}/lzo/lib"
+  export AL_OPTS="-I${PACKAGES}/pkg-config/share/aclocal ${AL_OPTS}"
+}
+
+tar xvzf xfs-progs/xfsprogs-4.20.0.tar.gz
+(
+  cd xfsprogs-4.20.0
+
+  setDeps
+
+  ./configure --prefix=$BOSH_INSTALL_TARGET
+  make
+  make install prefix=$BOSH_INSTALL_TARGET
+)

--- a/packages/xfs-progs/spec
+++ b/packages/xfs-progs/spec
@@ -1,0 +1,14 @@
+---
+name: xfs-progs
+
+dependencies:
+- autoconf
+- automake
+- libtool
+- lzo
+- pkg-config
+- util-linux
+- zlib
+
+files:
+- xfs-progs/xfsprogs-4.20.0.tar.gz

--- a/packages/zlib/packaging
+++ b/packages/zlib/packaging
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="1.2.11"
+
+tar xvzf "zlib/zlib-${version}.tar.gz"
+
+cd "zlib-${version}"
+
+./configure "--prefix=${BOSH_INSTALL_TARGET}"
+make
+make install "prefix=${BOSH_INSTALL_TARGET}"

--- a/packages/zlib/spec
+++ b/packages/zlib/spec
@@ -1,0 +1,11 @@
+---
+name: zlib
+
+dependencies:
+- autoconf
+- automake
+- libtool
+- pkg-config
+
+files:
+- zlib/*


### PR DESCRIPTION
Revert cloudfoundry/garden-runc-release#243. Main reason for the revert is [this comment](https://github.com/cloudfoundry/garden-runc-release/pull/212#issuecomment-983784145-permalink) for stemcell lines on older versions of Jammy.