### PR TITLE
Creates loop-control device node to avoid problems

### DIFF
--- a/ci/helpers/device-control.bash
+++ b/ci/helpers/device-control.bash
@@ -39,6 +39,13 @@ function permit_device_control() {
 
 function create_loop_devices() {
   set +ex
+  LOOP_CONTROL=/dev/loop-control
+  if [ ! -c $LOOP_CONTROL ]; then
+    mknod $LOOP_CONTROL c 10 237
+    chown root:disk $LOOP_CONTROL
+    chmod 660 $LOOP_CONTROL
+  fi
+
   amt=${1:-256}
   for i in $( seq 0 "$amt" ); do
     mknod -m 0660 "/dev/loop${i}" b 7 "$i" > /dev/null 2>&1

--- a/src/greenskeeper/scripts/system-preparation
+++ b/src/greenskeeper/scripts/system-preparation
@@ -34,6 +34,13 @@ function permit_device_control() {
 }
 
 function create_loop_devices() {
+  LOOP_CONTROL=/dev/loop-control
+  if [ ! -c $LOOP_CONTROL ]; then
+    mknod $LOOP_CONTROL c 10 237
+    chown root:disk $LOOP_CONTROL
+    chmod 660 $LOOP_CONTROL
+  fi
+
   amt=$1
   for i in $(seq 0 $amt); do
     if [ ! -e /dev/loop$i ]; then


### PR DESCRIPTION
Without `/dev/loop-control`, losetup will fail to find a device when the first 8 loopback devices are in use.

This absence will cause 'failed to setup loop device for $PATH' errors that could otherwise be avoided, such as the following message found in `garden_ctl.stdout.log` from a failed start of `garden` using `garden_ctl start`:

```
exit status 32: mount: /var/vcap/data/grootfs/store/privileged: failed to setup loop device for /var/vcap/data/grootfs/store/privileged.backing-store.
```