### PR TITLE
Fix sync-package-specs pathing for CI invocation

### DIFF
--- a/scripts/sync-package-specs
+++ b/scripts/sync-package-specs
@@ -2,6 +2,9 @@
 
 set -e
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+RELEASE_DIR="$(realpath ${SCRIPT_DIR}/..)"
+
 source "$RELEASE_DIR/ci/helpers/build-binaries.bash"
 build_gosub "$RELEASE_DIR" "$RELEASE_DIR/bin"
 


### PR DESCRIPTION
Fixes:
```
+ ./scripts/sync-package-specs
./scripts/sync-package-specs: line 5: /ci/helpers/build-binaries.bash: No such file or directory
```

`./scripts/sync-package-specs` used to rely on the `RELEASE_DIR` env variable to run. This is fine for local development but we don't necessarily need to use / would rather not use direnv in CI.

This change updates the `sync-package-specs` to automatically calculate the `RELEASE_DIR` upon invocation of the script.