### PR TITLE
Standardize ci invocation of ginkgo

### DIFF
--- a/ci/dontpanic/task.yml
+++ b/ci/dontpanic/task.yml
@@ -11,4 +11,4 @@ run:
   - -ceux
   - |
     cd release/src/dontpanic
-    ginkgo -p -nodes 5 -race -skipPackage "integration" -r
+    go run github.com/onsi/ginkgo/v2/ginkgo -r -p --nodes 5 --race --skip-package 'integration'

--- a/ci/greenskeeper/task.yml
+++ b/ci/greenskeeper/task.yml
@@ -10,4 +10,4 @@ run:
   - -ceux
   - |
     cd release/src/greenskeeper
-    ginkgo --race -r --randomizeAllSpecs "$@"
+    go run github.com/onsi/ginkgo/v2/ginkgo -r --race --randomize-all

--- a/ci/guardian-standalone/task
+++ b/ci/guardian-standalone/task
@@ -139,7 +139,7 @@ function test() {
   export ROOTLESS=false
   export CONTAINERD_FOR_PROCESSES_ENABLED=false
 
-  go run github.com/onsi/ginkgo/v2/ginkgo -p -nodes 8 -fail-on-pending -randomize-suites -randomize-all "${@}"
+  go run github.com/onsi/ginkgo/v2/ginkgo -p --nodes 8 --fail-on-pending --randomize-suites --randomize-all "${@}"
 }
 
 function verify() {

--- a/ci/idmapper/task.yml
+++ b/ci/idmapper/task.yml
@@ -11,4 +11,4 @@ run:
   - -ceux
   - |
     cd release/src/idmapper
-    ginkgo -p -race -r "$@"
+    go run github.com/onsi/ginkgo/v2/ginkgo -r -p --race

--- a/ci/netplugin-shim/task.yml
+++ b/ci/netplugin-shim/task.yml
@@ -10,4 +10,4 @@ run:
   - -ceux
   - |
     cd release/src/netplugin-shim
-    ginkgo --race --nodes 8 --keepGoing --failOnPending --randomizeSuites --randomizeAllSpecs -r $*
+    go run github.com/onsi/ginkgo/v2/ginkgo -r --race --nodes 8 --keep-going --fail-on-pending --randomize-suites --randomize-all

--- a/ci/thresholder/task.yml
+++ b/ci/thresholder/task.yml
@@ -16,5 +16,4 @@ run:
     create_loop_devices 256
 
     cd release/src/thresholder
-    ginkgo --race -r --randomizeAllSpecs "$@"
-
+    go run github.com/onsi/ginkgo/v2/ginkgo -r --race --randomize-all


### PR DESCRIPTION
Fixes errors like
```
  Ginkgo CLI Version:
    2.10.0
  Mismatched package versions found:
    2.11.0 used by thresholder, calculator, disk
```

Instead of relying on the version of ginkgo present on the CI container, run the version of ginkgo specified in the go mod directly. Also removes some unnecessary `$*` and `$@`.

Standardizes with commits like:
- https://github.com/cloudfoundry/garden-runc-release/commit/e2adbf0ad428aec0784654ec710b2f62ef5a18a2
- https://github.com/cloudfoundry/garden-runc-release/commit/3503f95cc7a17b242f715fea95fb2fe234f8cac4