### PR TITLE
Standardize ci invocation of ginkgo for `garden`

### DIFF
--- a/ci/garden/task.yml
+++ b/ci/garden/task.yml
@@ -15,5 +15,4 @@ run:
     git config --global --add safe.directory '*'
     cd release/src/garden
     go vet ./...
-    ginkgo -r -p --race --keepGoing --nodes="${GINKGO_NODES}" --failOnPending --randomizeSuites --randomizeAllSpecs "$@"
-
+    go run github.com/onsi/ginkgo/v2/ginkgo -r -p --race --keep-going --nodes="${GINKGO_NODES}" --fail-on-pending --randomize-suites --randomize-all


### PR DESCRIPTION
I forgot to change one of the jobs (garden).

Follow up to:
- https://github.com/cloudfoundry/garden-runc-release/pull/286
- https://github.com/cloudfoundry/garden-runc-release/commit/17bba205ae18fe9c34ec4de9cfacd86e04f0d6b5

Fixes errors like
```
  Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.10.0
  Mismatched package versions found:
    2.11.0 used by garden, client, connection, server, bomberman, streamer, timebomb
```

Instead of relying on the version of ginkgo present on the CI container, run the version of ginkgo specified in the go mod directly. Also removes some unnecessary `$*` and `$@`.

Standardizes with commits like:
- https://github.com/cloudfoundry/garden-runc-release/commit/e2adbf0ad428aec0784654ec710b2f62ef5a18a2
- https://github.com/cloudfoundry/garden-runc-release/commit/3503f95cc7a17b242f715fea95fb2fe234f8cac4