### PR TITLE
added feature flag for container network metrics

### DIFF
--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -119,6 +119,10 @@ properties:
     description: "Additional hosts file entries to be used in containers."
     default: []
 
+  garden.enable_container_network_metrics:
+    description: "Enable container network metrics. This feature is only available on Linux."
+    default: false
+
   garden.insecure_docker_registry_list:
     description: "DEPRECATED in favour of grootfs property."
     default: []

--- a/jobs/garden/templates/config/config.ini.erb
+++ b/jobs/garden/templates/config/config.ini.erb
@@ -188,6 +188,9 @@ parse_ip(p('garden.network_pool'), 'garden.network_pool')
 <% p("garden.additional_host_entries").each do |host_entry| -%>
   additional-host-entry = "<%= host_entry %>"
 <% end -%>
+<% if p("garden.enable_container_network_metrics") -%>
+  enable-container-network-metrics = true
+<% end -%>
 
 ; properties
   properties-path = /var/vcap/data/garden/props.json

--- a/spec/jobs/garden_spec.rb
+++ b/spec/jobs/garden_spec.rb
@@ -218,6 +218,24 @@ describe 'garden' do
       it 'sets the time-format' do
         expect(rendered_template['server']['time-format']).to eql('unix-epoch')
       end
+
+      it 'does not enable the container network metrics' do
+        expect(rendered_template['server']['enable-container-network-metrics']).to eql(nil)
+      end
+
+      context 'when container network metrics are enabled' do
+        let(:properties) {
+          {
+            'garden' => {
+              'enable_container_network_metrics' => true,
+            }
+          }
+        }
+
+        it 'sets the enable container network metrics to true' do
+          expect(rendered_template['server']['enable-container-network-metrics']).to eql(true)
+        end
+      end
     end
 
     context 'with a listen address' do


### PR DESCRIPTION
* Related to https://github.com/cloudfoundry/cf-networking-release/issues/64
* Feature flag to enable container network metrics implemented in [this guardian PR](https://github.com/cloudfoundry/guardian/pull/417).
* Addresses the comment in the `diego-logging-client` pointing out that this metric may not be of interest to everyone.
  * https://github.com/cloudfoundry/diego-logging-client/pull/82#issuecomment-1662498944 