### PR TITLE
Enable guardian-windows to cleanup process state.

### DIFF
--- a/jobs/garden-windows/spec
+++ b/jobs/garden-windows/spec
@@ -69,6 +69,12 @@ properties:
     description: "path to the rootfs to use when a container specifies no rootfs"
     default: ""
 
+  # Since garden-windows is not currently used in Concourse, we are setting this to 'true' to make life easier for diego/cf users.
+  # https://github.com/cloudfoundry/garden-runc-release/releases/tag/v1.5.0
+  garden.cleanup_process_dirs_on_wait:
+    description: A boolean stating whether or not to cleanup process state after waiting for it. If set a process can be waited for only once.
+    default: true
+
   logging.format.timestamp:
     description: "Format for timestamp in component logs. Valid values are 'unix-epoch' and 'rfc3339'."
     default: "unix-epoch"

--- a/jobs/garden-windows/templates/garden_ctl.ps1.erb
+++ b/jobs/garden-windows/templates/garden_ctl.ps1.erb
@@ -69,4 +69,7 @@ C:\var\vcap\packages\guardian-windows\gdn.exe `
     <% raise "logging.format.timestamp should be one of: 'unix-epoch' or 'rfc3339'" %> `
   <% end %> `
   --time-format=<%= format %> `
+  <% end %> `
+  <% if p("garden.cleanup_process_dirs_on_wait") == true %> `
+  --cleanup-process-dirs-on-wait `
   <% end %>

--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -201,6 +201,8 @@ properties:
     description: A boolean stating whether or not to run garden-server as a non-root user
     default: false
 
+  # We believe this defaults to false to help concourse: https://github.com/cloudfoundry/garden-runc-release/releases/tag/v1.5.0
+  # For diego/cf, this should be set to true
   garden.cleanup_process_dirs_on_wait:
     description: A boolean stating whether or not to cleanup process state after waiting for it. If set a process can be waited for only once.
     default: false


### PR DESCRIPTION
This uses similar logic to guardian on Linux, but we defaulted the behavior (`cleanup_process_dirs_on_wait`) to be enabled. We believe it was disabled in Linux for Concourse when originally implemented, as Diego/CF require it to be on. Since Concourse doesn't use garden on Windows workers, we defaulted this on to make it easier on the CF side.

[#185836130](https://www.pivotaltracker.com/story/show/185836130)