### PR TITLE
Remove unused healthchecker packages

### DIFF
--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -39,7 +39,6 @@ packages:
   - netplugin-shim
   - dontpanic
   - tini
-  - garden-runc-healthchecker
 
 provides:
 - name: iptables

--- a/packages/garden-runc-golang-1.21-linux/spec.lock
+++ b/packages/garden-runc-golang-1.21-linux/spec.lock
@@ -1,2 +1,0 @@
-name: garden-runc-golang-1.21-linux
-fingerprint: 48a59edbcdab872874d3b1851402c38b62fbf4a70ebfbd055a9d63865f021a69

--- a/packages/garden-runc-healthchecker/spec.lock
+++ b/packages/garden-runc-healthchecker/spec.lock
@@ -1,4 +1,0 @@
-name: garden-runc-healthchecker
-fingerprint: fd4d1a280162624a7a0dd0ad2fcc7d03756322d571181ba41779eefec8345c21
-dependencies:
-- garden-runc-golang-1.21-linux


### PR DESCRIPTION
We removed the usage of this package [here](https://github.com/cloudfoundry/garden-runc-release/pull/309)