### PR TITLE
Add max_containers bosh link   

### DIFF
--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -45,6 +45,11 @@ provides:
   type: iptables
   properties:
   - garden.iptables_bin_dir
+  
+- name: max_containers
+  type: max_containers
+  properties:
+  - garden.max_containers
 
 properties:
   garden.listen_network:

--- a/jobs/garden/templates/config/config.ini.erb
+++ b/jobs/garden/templates/config/config.ini.erb
@@ -89,6 +89,9 @@ parse_ip(p('garden.network_pool'), 'garden.network_pool')
 <% end -%>
 <% if_p("garden.max_containers") do |max_containers| -%>
   max-containers = <%= max_containers %>
+  <% if max-containers <= 0 -%>
+    <% raise "max-containers should be a positive integer" -%>
+  <% end -%>
 <% end -%>
 <% if p("garden.cleanup_process_dirs_on_wait") -%>
   cleanup-process-dirs-on-wait = true

--- a/jobs/garden/templates/config/config.ini.erb
+++ b/jobs/garden/templates/config/config.ini.erb
@@ -88,10 +88,10 @@ parse_ip(p('garden.network_pool'), 'garden.network_pool')
   destroy-containers-on-startup = true
 <% end -%>
 <% if_p("garden.max_containers") do |max_containers| -%>
-  max-containers = <%= max_containers %>
-  <% if max-containers <= 0 -%>
+  <% if max_containers <= 0 -%>
     <% raise "max-containers should be a positive integer" -%>
   <% end -%>
+  max-containers = <%= max_containers %>
 <% end -%>
 <% if p("garden.cleanup_process_dirs_on_wait") -%>
   cleanup-process-dirs-on-wait = true

--- a/spec/jobs/garden_spec.rb
+++ b/spec/jobs/garden_spec.rb
@@ -91,17 +91,17 @@ describe 'garden' do
         expect(rendered_template['server']['cpu-entitlement-per-share']).to eql(0)
       end
 
-      context 'when we change the default value of garden.max_containers' do 
-        it('checks if max_containers is a positive integer') do 
-          let(:properties) {
+      context 'checks if max_containers is a positive integer' do 
+        let(:properties) {
           {
             'garden' => {
               'max_containers' => -10,
             }
           }
+        }
+        it 'raises an error for a non-positive integer' do
           error_msg = 'max-containers should be a positive integer'
           expect { rendered_template }.to raise_error(error_msg)
-        }
         end
       end
 

--- a/spec/jobs/garden_spec.rb
+++ b/spec/jobs/garden_spec.rb
@@ -91,6 +91,20 @@ describe 'garden' do
         expect(rendered_template['server']['cpu-entitlement-per-share']).to eql(0)
       end
 
+      context 'when we change the default value of garden.max_containers' do 
+        it('checks if max_containers is a positive integer') do 
+          let(:properties) {
+          {
+            'garden' => {
+              'max_containers' => -10,
+            }
+          }
+          error_msg = 'max-containers should be a positive integer'
+          expect { rendered_template }.to raise_error(error_msg)
+        }
+        end
+      end
+
       context 'cpu throttling' do
         context 'by default' do
           it 'sets the enable cpu throttling per share to false' do


### PR DESCRIPTION
Add a bosh link for max_containers so it can be used in the rep. Includes template test to check if max_containers is a positive integer. More info here: https://github.com/cloudfoundry/diego-release/issues/867