### PR TITLE
Patch runc's makefile on Xenial to allow it to compile

### DIFF
--- a/packages/containerd/spec
+++ b/packages/containerd/spec
@@ -8,6 +8,7 @@ files:
   - guardian/go.mod
   - guardian/go.sum
   - guardian/vendor/modules.txt
+  - guardian/vendor/dario.cat/mergo/*.go # gosub
   - guardian/vendor/github.com/Microsoft/go-winio/*.go # gosub
   - guardian/vendor/github.com/Microsoft/go-winio/backuptar/*.go # gosub
   - guardian/vendor/github.com/Microsoft/go-winio/internal/fs/*.go # gosub
@@ -72,7 +73,10 @@ files:
   - guardian/vendor/github.com/cilium/ebpf/internal/unix/*.go # gosub
   - guardian/vendor/github.com/cilium/ebpf/link/*.go # gosub
   - guardian/vendor/github.com/container-orchestrated-devices/container-device-interface/internal/multierror/*.go # gosub
+  - guardian/vendor/github.com/container-orchestrated-devices/container-device-interface/internal/validation/*.go # gosub
+  - guardian/vendor/github.com/container-orchestrated-devices/container-device-interface/internal/validation/k8s/*.go # gosub
   - guardian/vendor/github.com/container-orchestrated-devices/container-device-interface/pkg/cdi/*.go # gosub
+  - guardian/vendor/github.com/container-orchestrated-devices/container-device-interface/pkg/parser/*.go # gosub
   - guardian/vendor/github.com/container-orchestrated-devices/container-device-interface/specs-go/*.go # gosub
   - guardian/vendor/github.com/containerd/aufs/*.go # gosub
   - guardian/vendor/github.com/containerd/aufs/plugin/*.go # gosub
@@ -446,7 +450,6 @@ files:
   - guardian/vendor/github.com/hashicorp/errwrap/*.go # gosub
   - guardian/vendor/github.com/hashicorp/go-multierror/*.go # gosub
   - guardian/vendor/github.com/hashicorp/go-multierror/Makefile # gosub
-  - guardian/vendor/github.com/imdario/mergo/*.go # gosub
   - guardian/vendor/github.com/intel/goresctrl/pkg/blockio/*.go # gosub
   - guardian/vendor/github.com/intel/goresctrl/pkg/cgroups/*.go # gosub
   - guardian/vendor/github.com/intel/goresctrl/pkg/kubernetes/*.go # gosub
@@ -482,6 +485,7 @@ files:
   - guardian/vendor/github.com/moby/sys/sequential/*.go # gosub
   - guardian/vendor/github.com/moby/sys/signal/*.go # gosub
   - guardian/vendor/github.com/moby/sys/symlink/*.go # gosub
+  - guardian/vendor/github.com/moby/sys/user/*.go # gosub
   - guardian/vendor/github.com/modern-go/concurrent/*.go # gosub
   - guardian/vendor/github.com/modern-go/reflect2/*.go # gosub
   - guardian/vendor/github.com/modern-go/reflect2/*.s # gosub
@@ -490,8 +494,6 @@ files:
   - guardian/vendor/github.com/opencontainers/image-spec/identity/*.go # gosub
   - guardian/vendor/github.com/opencontainers/image-spec/specs-go/*.go # gosub
   - guardian/vendor/github.com/opencontainers/image-spec/specs-go/v1/*.go # gosub
-  - guardian/vendor/github.com/opencontainers/runc/libcontainer/devices/*.go # gosub
-  - guardian/vendor/github.com/opencontainers/runc/libcontainer/user/*.go # gosub
   - guardian/vendor/github.com/opencontainers/runtime-spec/specs-go/*.go # gosub
   - guardian/vendor/github.com/opencontainers/runtime-tools/generate/*.go # gosub
   - guardian/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/*.go # gosub
@@ -572,6 +574,7 @@ files:
   - guardian/vendor/go.opentelemetry.io/otel/sdk/resource/*.go # gosub
   - guardian/vendor/go.opentelemetry.io/otel/sdk/trace/*.go # gosub
   - guardian/vendor/go.opentelemetry.io/otel/semconv/v1.17.0/*.go # gosub
+  - guardian/vendor/go.opentelemetry.io/otel/semconv/v1.20.0/*.go # gosub
   - guardian/vendor/go.opentelemetry.io/otel/semconv/v1.21.0/*.go # gosub
   - guardian/vendor/go.opentelemetry.io/otel/trace/*.go # gosub
   - guardian/vendor/go.opentelemetry.io/proto/otlp/collector/trace/v1/*.go # gosub
@@ -601,7 +604,6 @@ files:
   - guardian/vendor/golang.org/x/oauth2/internal/*.go # gosub
   - guardian/vendor/golang.org/x/sync/errgroup/*.go # gosub
   - guardian/vendor/golang.org/x/sync/semaphore/*.go # gosub
-  - guardian/vendor/golang.org/x/sys/execabs/*.go # gosub
   - guardian/vendor/golang.org/x/sys/unix/*.go # gosub
   - guardian/vendor/golang.org/x/sys/unix/*.s # gosub
   - guardian/vendor/golang.org/x/sys/unix/*.c # gosub

--- a/packages/runc/packaging
+++ b/packages/runc/packaging
@@ -15,6 +15,24 @@ source /var/vcap/packages/golang-*-linux/bosh/compile.env
 mkdir -p "${BOSH_INSTALL_TARGET}/bin"
 export GOBIN="${BOSH_INSTALL_TARGET}/bin"
 
+. /etc/lsb-release
+if [[ "${DISTRIB_CODENAME}" == "xenial" ]]; then
+  patch -r Makefile-xenial.rej -F 0 \
+    src/guardian/vendor/github.com/opencontainers/runc/Makefile \
+    src/runc-patches/Makefile-xenial.patch \
+    >&2 || true >&2
+  # there are cases where patch can return 0, but will still generate a .rej file since
+  # it tried to be smart and figure out how to apply the patch. We'd like to err on the side
+  # of failure and requiring human eyes just in case. As a result, we ignore the exit code,
+  # and look for the reject file to tell us things failed.
+  if [[ -f Makefile-xenial.rej ]]; then
+    echo "Patching Makefile with Makefile-xenial.patch failed" >&2
+    echo "Please resolve the issue manually until patching succeeds and does not generate a .rej file:" >&2
+    echo "'patch -r Makefile-xenial.rej -F 0 src/guardian/vendor/github.com/opencontainers/runc/Makefile src/runc-patches/Makefile-xenial.patch' succeeds" >&2
+    exit 1
+  fi
+fi
+
 pushd src/guardian/vendor/github.com/opencontainers/runc
   make BUILDTAGS='seccomp apparmor' static
   cp runc "${GOBIN}/runc"

--- a/packages/runc/spec
+++ b/packages/runc/spec
@@ -7,6 +7,7 @@ dependencies:
   - pkg-config
 
 files:
+  - runc-patches/*.patch
   - guardian/go.mod
   - guardian/go.sum
   - guardian/vendor/modules.txt
@@ -59,6 +60,7 @@ files:
   - guardian/vendor/github.com/opencontainers/runc/libcontainer/system/*.go # gosub
   - guardian/vendor/github.com/opencontainers/runc/libcontainer/user/*.go # gosub
   - guardian/vendor/github.com/opencontainers/runc/libcontainer/userns/*.go # gosub
+  - guardian/vendor/github.com/opencontainers/runc/libcontainer/userns/*.c # gosub
   - guardian/vendor/github.com/opencontainers/runc/libcontainer/utils/*.go # gosub
   - guardian/vendor/github.com/opencontainers/runc/types/*.go # gosub
   - guardian/vendor/github.com/opencontainers/runc/types/features/*.go # gosub

--- a/src/runc-patches/Makefile-xenial.patch
+++ b/src/runc-patches/Makefile-xenial.patch
@@ -1,0 +1,31 @@
+--- Makefile	2024-01-29 17:12:58.881268462 +0000
++++ Makefile-xenial	2024-01-29 18:27:03.668574864 +0000
+@@ -18,28 +18,12 @@
+ GOARCH := $(shell $(GO) env GOARCH)
+ 
+ GO_BUILDMODE :=
+-# Enable dynamic PIE executables on supported platforms.
+-ifneq (,$(filter $(GOARCH),386 amd64 arm arm64 ppc64le riscv64 s390x))
+-	ifeq (,$(findstring -race,$(EXTRA_FLAGS)))
+-		GO_BUILDMODE := "-buildmode=pie"
+-	endif
+-endif
+ GO_BUILD := $(GO) build -trimpath $(GO_BUILDMODE) \
+ 	$(EXTRA_FLAGS) -tags "$(BUILDTAGS)" \
+ 	-ldflags "$(LDFLAGS_COMMON) $(EXTRA_LDFLAGS)"
+ 
+ GO_BUILDMODE_STATIC :=
+ LDFLAGS_STATIC := -extldflags -static
+-# Enable static PIE executables on supported platforms.
+-# This (among the other things) requires libc support (rcrt1.o), which seems
+-# to be available only for arm64 and amd64 (Debian Bullseye).
+-ifneq (,$(filter $(GOARCH),arm64 amd64))
+-	ifeq (,$(findstring -race,$(EXTRA_FLAGS)))
+-		GO_BUILDMODE_STATIC := -buildmode=pie
+-		LDFLAGS_STATIC := -linkmode external -extldflags --static-pie
+-	endif
+-endif
+-# Enable static PIE binaries on supported platforms.
+ GO_BUILD_STATIC := $(GO) build -trimpath $(GO_BUILDMODE_STATIC) \
+ 	$(EXTRA_FLAGS) -tags "$(BUILDTAGS) netgo osusergo" \
+ 	-ldflags "$(LDFLAGS_COMMON) $(LDFLAGS_STATIC) $(EXTRA_LDFLAGS)"


### PR DESCRIPTION
Don't add `--static-pie` to runc compilation when on xenial, as the OS doesn't have a GCC version new enough to support it.