### PR TITLE
Fix fly/test-all.bash pathing

### DIFF
--- a/scripts/fly/test-all.bash
+++ b/scripts/fly/test-all.bash
@@ -4,7 +4,7 @@ set -eu
 set -o pipefail
 
 THIS_FILE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-CI="${THIS_FILE_DIR}/../../wg-app-platform-runtime-ci"
+CI="$(realpath "${THIS_FILE_DIR}/../../../wg-app-platform-runtime-ci")"
 . "$CI/shared/helpers/git-helpers.bash"
 REPO_NAME=$(git_get_remote_name)
 


### PR DESCRIPTION
There aren't enough `..` to go up dirs.