### PR TITLE
Deprecate containerd for processes

### DIFF
--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -229,7 +229,7 @@ properties:
     description: Sets the `net.ipv4.tcp_retries2` kernel parameter in containers. If not specified, the value from the linux init_net namespace is used.
 
   garden.experimental_use_containerd_mode_for_processes:
-    description: "(Under development) Use containerd for container process management. Must be used with containerd_mode also set to true. NOTE: cannot be used in combination with bpm or rootless"
+    description: "(Deprecated) No longer used/tested."
     default: false
 
   garden.experimental_cpu_throttling:

--- a/jobs/garden/templates/config/config.ini.erb
+++ b/jobs/garden/templates/config/config.ini.erb
@@ -253,7 +253,4 @@ parse_ip(p('garden.network_pool'), 'garden.network_pool')
 	<% else -%>
   containerd-socket = /var/vcap/sys/run/containerd/containerd.sock
   <% end -%>
-  <% if p("garden.experimental_use_containerd_mode_for_processes") -%>
-  use-containerd-for-processes = true
-  <% end -%>
 <% end -%>

--- a/jobs/gats/spec
+++ b/jobs/gats/spec
@@ -22,9 +22,6 @@ properties:
   garden_test_rootfs:
     description: Test rootfs to use
     default: 'docker:///cloudfoundry/garden-rootfs'
-  containerd_for_processes:
-    description: Run GATS with CONTAINERD_FOR_PROCESSES_ENABLED
-    default: false
   rootless:
     description: Run GATS with ROOTLESS env var
     default: false

--- a/jobs/gats/templates/run.erb
+++ b/jobs/gats/templates/run.erb
@@ -9,7 +9,6 @@ cd packages/gats/bin
 
 export GDN_BIND_IP="<%= p("garden_address") %>"
 export GDN_BIND_PORT="<%= p("garden_port") %>"
-export CONTAINERD_FOR_PROCESSES_ENABLED="<%= p("containerd_for_processes") %>"
 export ROOTLESS="<%= p("rootless") %>"
 export CPU_THROTTLING_ENABLED="<%= p("cpu_throttling") %>"
 export GARDEN_TEST_ROOTFS="<%= p("garden_test_rootfs") %>"


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Context: cloudfoundry/garden-runc-release#317

Backward Compatibility
---------------
Breaking Change? **Yes**

`containerd_for_processes` has been removed from `gats` errand. It
should be noted in release notes, but will not be breaking user who
consume this release in CF.
