### PR TITLE
Switch default mode to containerd_mode

### DIFF
--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -211,7 +211,7 @@ properties:
 
   garden.containerd_mode:
     description: "Use containerd for container lifecycle management. NOTE: cannot be used in combination with bpm or rootless"
-    default: false
+    default: true
 
   garden.tcp_keepalive_time:
     description: Sets the `net.ipv4.tcp_keepalive_time` kernel parameter in containers. If not specified, the value from the linux init_net namespace is used.


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Switch default mode to containerd_mode for garden in this release. This
has been the default in cf-deployment since 2018.

Context: cloudfoundry/garden-runc-release#315

Backward Compatibility
---------------
Breaking Change? **No**
