### PR TITLE
Allow garden container to use BOSH network spec IP as external IP

### DIFF
--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -177,6 +177,10 @@ properties:
     description: "If true, container is not going to be limited in swap space. Should only be used if swap is disabled on the VM."
     default: false
 
+  garden.use_network_spec_ip:
+    description: "If true, the instance IP specified from the BOSH spec object (https://bosh.io/docs/jobs/#properties-spec) will be used as the garden container's external IP."
+    default: false
+
   garden.destroy_containers_on_start:
     description: "If true, all existing containers will be destroyed any time the garden server starts up"
     default: false

--- a/jobs/garden/templates/config/config.ini.erb
+++ b/jobs/garden/templates/config/config.ini.erb
@@ -190,6 +190,9 @@ parse_ip(p('garden.network_pool'), 'garden.network_pool')
 <% if p("garden.enable_container_network_metrics") -%>
   enable-container-network-metrics = true
 <% end -%>
+<% if p("garden.use_network_spec_ip") -%>
+  external-ip = <%= spec.ip %>
+<% end -%>
 
 ; properties
   properties-path = /var/vcap/data/garden/props.json


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Add a new garden job spec boolean property `garden.use_network_spec_ip`.
When set as true, the instance IP specified from the BOSH spec object
will be used as the garden container's external IP. Having this property
could give users more control on garden job configuration.
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
