### PR TITLE
Improve docs about the 'bpm.enabled' property

### DIFF
--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -300,7 +300,21 @@ properties:
     default: false
 
   bpm.enabled:
-    description: "Use bpm. NOTE: this requires a recreate when enabling for the first time, otherwise old containers may be left running. NOTE: When this property is enabled, containers won't survive a restart of the garden job. This is why garden.destroy_containers_on_start should be set to avoid leaking container state."
+    description: |
+      Use BPM to run garden.
+
+      This in incompatible with recent stemcells that use systemd. Indeed,
+      then only way for sysyemd not to mess up with the garden-managed cgroups
+      (whether in containerd mode or not), is to run garden as a systemd
+      service with the 'Delegate=yes' property. Bosh-Lite (Warden) stemcells
+      are a noticable exception, as these don't use systemd.
+
+      Changing this property requires a recreate when enabling for the first
+      time, otherwise old containers may be left running.
+
+      When this property is enabled, containers won't survive a restart of the
+      garden job. This is why 'garden.destroy_containers_on_start' should be
+      set to 'true' to avoid leaking container state.
     default: false
 
   logging.format.timestamp:


### PR DESCRIPTION
Hi there,
After having worked extensively on running ContainerD with BPM in yet another Kubernetes BOSH Release (which is still private though), I wanted to update the docs here about the consequences of enabling BPM, now that Garden (using ContainerD by default) relies on being run by systemd for the sake of its cgroups being preserved.

And to bring a bit more context in: as mentioned in my recent talk (in May) https://youtu.be/pVxKltt4egI?t=495s in 2024 release authors _must_ use BPM. That's also related to the preparation work in Noble stemcells for an alternative to using Monit (tracked in cloudfoundry/community#892). That's why I've worked so hard recently at solving the challenge of running ContainerD using BPM. I'll submit a talk and publish my work soon.

Don't hesitate to raise any concerns, mention necessary additions or correct anything that wouldn't be accurate.
Best,
Benjamin