### PR TITLE
Update docker/test.bash for ignoring acceptance tests

### DIFF
--- a/scripts/docker/test.bash
+++ b/scripts/docker/test.bash
@@ -26,7 +26,7 @@ pushd / > /dev/null
 if [[ -n "${1:-}" ]]; then
   test "src/${1}" "${2:-}"
 else
-  internal_repos=$(yq -r '.internal_repos|.[].name' "/ci/$REPO_NAME/index.yml")
+  internal_repos=$(yq -r '.internal_repos[]  | select(.acceptance != true) | .name' "/ci/$REPO_NAME/index.yml")
   for component in $internal_repos; do
     test "src/${component}"
   done


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Ignores acceptance tests in ./scripts/docker/test.bash like CI does


Backward Compatibility
---------------
Breaking Change? **Nope**
