### PR TITLE
Allow to configure read-header-timeout

### DIFF
--- a/jobs/garden-windows/spec
+++ b/jobs/garden-windows/spec
@@ -36,6 +36,10 @@ properties:
     description: "An array of additional arguments which will be passed to the runtime plugin binary"
     default: []
 
+  garden.read_header_timeout:
+    description: "The amount of time allowed to read request headers"
+    default: 30s
+
   garden.image_plugin:
     description: "Path to an image plugin binary"
 

--- a/jobs/garden-windows/templates/garden_ctl.ps1.erb
+++ b/jobs/garden-windows/templates/garden_ctl.ps1.erb
@@ -32,6 +32,7 @@ C:\var\vcap\packages\guardian-windows\gdn.exe `
   server `
   --skip-setup `
   --depot=$depotDir `
+  --read-header-timeout=<%= p("garden.read_header_timeout") %> `
   --log-level=<%= p("garden.log_level") %> `
   <% ip, port = p("garden.listen_address").split(":") %> `
   --bind-ip=<%= ip %> `

--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -128,6 +128,10 @@ properties:
     description: "Path to a runtime plugin binary"
     default: /var/vcap/packages/runc/bin/runc
 
+  garden.read_header_timeout:
+    description: "The amount of time allowed to read request headers"
+    default: 30s
+
   garden.no_image_plugin:
     description: "If true, disables image plugin usage, thus ignoring other image plugin settings"
     default: false

--- a/jobs/garden/templates/config/config.ini.erb
+++ b/jobs/garden/templates/config/config.ini.erb
@@ -241,6 +241,7 @@ parse_ip(p('garden.network_pool'), 'garden.network_pool')
   skip-setup = true
   depot = /var/vcap/data/garden/depot
   runtime-plugin=<%= p("garden.runtime_plugin") %>
+  read-header-timeout = <%= p("garden.read_header_timeout") %>
 
 <% if p("garden.containerd_mode") -%>
 ; containerd

--- a/spec/jobs/garden_spec.rb
+++ b/spec/jobs/garden_spec.rb
@@ -79,6 +79,10 @@ describe 'garden' do
         expect(rendered_template['server']['runtime-plugin']).to eql('/var/vcap/packages/runc/bin/runc')
       end
 
+      it 'sets the read header timeout to 30s' do
+        expect(rendered_template['server']['read-header-timeout']).to eql('30s')
+      end
+
       it 'sets the max containers to 250' do
         expect(rendered_template['server']['max-containers']).to eql(250)
       end


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
[Guardian server now accepts read-header-timeout option](https://github.com/cloudfoundry/guardian/commit/c94ed9c85e50cba77ecc387b8cb01cbd50ea404b). Pass this option with default of 30s. 


Backward Compatibility
---------------
Breaking Change? **Yes**

This change might be breaking for some clients of guardian server that send long requests.
