### PR TITLE
Create a top-level dir for libtool

### DIFF
--- a/packages/libtool/packaging
+++ b/packages/libtool/packaging
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-tar xzf libtool/libtool-*.tar.gz
+mkdir -p libtool-build
+tar xzf libtool/libtool-*.tar.gz -C libtool-build
 
-cd libtool-*
+pushd libtool-build
 
 ./configure "--prefix=${BOSH_INSTALL_TARGET}"
 make
 make install "prefix=${BOSH_INSTALL_TARGET}"
+
+popd


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
After using [jammy's source instead](https://github.com/cloudfoundry/wg-app-platform-runtime-ci/commit/f9c4a936336a24669bfb74cfba61a8772442fba3), the new blob will need a top-level dir.

Context: https://github.com/cloudfoundry/garden-runc-release/commit/576d2dc3f43994899bbebb01d21506250204fa93



Backward Compatibility
---------------
Breaking Change? **No**
