### PR TITLE
Setup cgroups v2 controllers inside docker container

### DIFF
--- a/scripts/docker/test.bash
+++ b/scripts/docker/test.bash
@@ -3,6 +3,17 @@
 set -eu
 set -o pipefail
 
+if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+    echo "Setting up controllers for cgroup v2"
+    # move the processes from the root group to the /init group,
+    # otherwise writing subtree_control fails with EBUSY
+    # An error during moving non-existent process (i.e., "cat") is ignored.
+    mkdir -p /sys/fs/cgroup/init
+    xargs -rn1 < /sys/fs/cgroup/cgroup.procs > /sys/fs/cgroup/init/cgroup.procs || :
+    # enable controllers
+    sed -e 's/ / +/g' -e 's/^/+/' < /sys/fs/cgroup/cgroup.controllers > /sys/fs/cgroup/cgroup.subtree_control
+fi
+
 . "/ci/shared/helpers/git-helpers.bash"
 
 function test() {


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
We want to enable all available controllers in our test docker container

Backward Compatibility
---------------
Breaking Change? **No**

