### PR TITLE
cleanup time format property

### DIFF
--- a/jobs/garden-windows/spec
+++ b/jobs/garden-windows/spec
@@ -78,7 +78,3 @@ properties:
   garden.cleanup_process_dirs_on_wait:
     description: A boolean stating whether or not to cleanup process state after waiting for it. If set a process can be waited for only once.
     default: true
-
-  logging.format.timestamp:
-    description: "Format for timestamp in component logs. Valid values are 'unix-epoch' and 'rfc3339'."
-    default: "unix-epoch"

--- a/jobs/garden-windows/templates/garden_ctl.ps1.erb
+++ b/jobs/garden-windows/templates/garden_ctl.ps1.erb
@@ -65,7 +65,6 @@ C:\var\vcap\packages\guardian-windows\gdn.exe `
   <% if p("garden.destroy_containers_on_start") %> `
   --destroy-containers-on-startup `
   <% end %> `
-  --time-format="rfc3339" `
   <% if p("garden.cleanup_process_dirs_on_wait") == true %> `
   --cleanup-process-dirs-on-wait `
   <% end %>

--- a/jobs/garden-windows/templates/garden_ctl.ps1.erb
+++ b/jobs/garden-windows/templates/garden_ctl.ps1.erb
@@ -65,12 +65,7 @@ C:\var\vcap\packages\guardian-windows\gdn.exe `
   <% if p("garden.destroy_containers_on_start") %> `
   --destroy-containers-on-startup `
   <% end %> `
-  <% if_p("logging.format.timestamp") do |format| %> `
-  <% if format != "unix-epoch" and format != "rfc3339" %> `
-    <% raise "logging.format.timestamp should be one of: 'unix-epoch' or 'rfc3339'" %> `
-  <% end %> `
-  --time-format=<%= format %> `
-  <% end %> `
+  --time-format="rfc3339" `
   <% if p("garden.cleanup_process_dirs_on_wait") == true %> `
   --cleanup-process-dirs-on-wait `
   <% end %>

--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -306,7 +306,3 @@ properties:
   bpm.enabled:
     description: "Use bpm. NOTE: this requires a recreate when enabling for the first time, otherwise old containers may be left running. NOTE: When this property is enabled, containers won't survive a restart of the garden job. This is why garden.destroy_containers_on_start should be set to avoid leaking container state."
     default: false
-
-  logging.format.timestamp:
-    description: "Format for timestamp in component logs. Valid values are 'unix-epoch' and 'rfc3339'."
-    default: "unix-epoch"

--- a/jobs/garden/templates/bin/containerd_utils.erb
+++ b/jobs/garden/templates/bin/containerd_utils.erb
@@ -16,11 +16,8 @@ log() {
   local time
 
   msg=$1
-  <% if p("logging.format.timestamp") == "unix-epoch" -%>
-  time=$(date -u +"%s.%N")
-  <% else -%>
+
   time=$(date -u +"%Y-%m-%dT%H:%M:%S.%NZ")
-  <% end -%>
 
   echo "$time $msg" >> "${LOG_DIR}/containerd_ctl.log"
 }

--- a/jobs/garden/templates/bin/garden_start.erb
+++ b/jobs/garden/templates/bin/garden_start.erb
@@ -51,9 +51,7 @@ setup_cmd="/var/vcap/packages/guardian/bin/gdn setup"
 <% if p("garden.experimental_cpu_throttling") %>
   setup_cmd="$setup_cmd --enable-cpu-throttling"
 <% end %>
-<% if p("logging.format.timestamp") == "rfc3339" -%>
-  setup_cmd="$setup_cmd --time-format=rfc3339"
-<% end -%>
+
 exec_command="exec"
 id_map_start=1
 

--- a/jobs/garden/templates/bin/grootfs-utils.erb
+++ b/jobs/garden/templates/bin/grootfs-utils.erb
@@ -25,11 +25,7 @@ log() {
   local time
 
   msg=$1
-  <% if p("logging.format.timestamp") == "unix-epoch" -%>
-  time=$(date -u +"%s.%N")
-  <% else -%>
   time=$(date -u +"%Y-%m-%dT%H:%M:%S.%NZ")
-  <% end -%>
 
   echo "$time - $msg"
 }

--- a/jobs/garden/templates/bin/overlay-xfs-setup
+++ b/jobs/garden/templates/bin/overlay-xfs-setup
@@ -50,7 +50,7 @@ ensure_successful_initialisation() {
   cwd=$(pwd)
   cd "$store"
   mkdir -p "$xfs_quota_test_dir"
-  /var/vcap/packages/grootfs/bin/tardis --log-timestamp-format "rfc3339" %>" limit --disk-limit-bytes 102400 --image-path "$xfs_quota_test_dir"
+  /var/vcap/packages/grootfs/bin/tardis limit --disk-limit-bytes 102400 --image-path "$xfs_quota_test_dir"
   rm -rf "$xfs_quota_test_dir"
   cd "$cwd"
 }

--- a/jobs/garden/templates/bin/overlay-xfs-setup
+++ b/jobs/garden/templates/bin/overlay-xfs-setup
@@ -50,7 +50,7 @@ ensure_successful_initialisation() {
   cwd=$(pwd)
   cd "$store"
   mkdir -p "$xfs_quota_test_dir"
-  /var/vcap/packages/grootfs/bin/tardis --log-timestamp-format "<%= p('logging.format.timestamp') %>" limit --disk-limit-bytes 102400 --image-path "$xfs_quota_test_dir"
+  /var/vcap/packages/grootfs/bin/tardis --log-timestamp-format "rfc3339" %>" limit --disk-limit-bytes 102400 --image-path "$xfs_quota_test_dir"
   rm -rf "$xfs_quota_test_dir"
   cd "$cwd"
 }

--- a/jobs/garden/templates/bin/post-start
+++ b/jobs/garden/templates/bin/post-start
@@ -6,11 +6,7 @@ log() {
   local time
 
   msg=$1
-  <% if p("logging.format.timestamp") == "unix-epoch" -%>
-  time=$(date -u +"%s.%N")
-  <% else -%>
   time=$(date -u +"%Y-%m-%dT%H:%M:%S.%NZ")
-  <% end -%>
 
   echo "$time: $msg"
 }

--- a/jobs/garden/templates/config/config.ini.erb
+++ b/jobs/garden/templates/config/config.ini.erb
@@ -232,12 +232,6 @@ parse_ip(p('garden.network_pool'), 'garden.network_pool')
   debug-bind-port = <%= debug_port %>
 <% end -%>
   log-level = <%= p("garden.log_level") %>
-<% if_p("logging.format.timestamp") do |format| -%>
-  <% if format != "unix-epoch" and format != "rfc3339" -%>
-    <% raise "logging.format.timestamp should be one of: 'unix-epoch' or 'rfc3339'" -%>
-  <% end -%>
-  time-format = <%= format %>
-<% end -%>
   skip-setup = true
   depot = /var/vcap/data/garden/depot
   runtime-plugin=<%= p("garden.runtime_plugin") %>

--- a/jobs/garden/templates/config/grootfs_config.yml.erb
+++ b/jobs/garden/templates/config/grootfs_config.yml.erb
@@ -6,7 +6,6 @@ log_level: <%= p("grootfs.log_level") %>
 <% if_p("grootfs.dropsonde_port") do |dropsonde_port| %>
 metron_endpoint: 127.0.0.1:<%= dropsonde_port %>
 <% end %>
-log_timestamp_format: "rfc3339"
 
 create:
   without_mount: <%= p("grootfs.skip_mount") %>

--- a/jobs/garden/templates/config/grootfs_config.yml.erb
+++ b/jobs/garden/templates/config/grootfs_config.yml.erb
@@ -6,9 +6,7 @@ log_level: <%= p("grootfs.log_level") %>
 <% if_p("grootfs.dropsonde_port") do |dropsonde_port| %>
 metron_endpoint: 127.0.0.1:<%= dropsonde_port %>
 <% end %>
-<% if_p("logging.format.timestamp") do |format| %>
-log_timestamp_format: <%= format %>
-<% end -%>
+log_timestamp_format: "rfc3339"
 
 create:
   without_mount: <%= p("grootfs.skip_mount") %>

--- a/jobs/garden/templates/config/privileged_grootfs_config.yml.erb
+++ b/jobs/garden/templates/config/privileged_grootfs_config.yml.erb
@@ -6,9 +6,7 @@ log_level: <%= p('grootfs.log_level') %>
 <% if_p("grootfs.dropsonde_port") do |dropsonde_port| %>
 metron_endpoint: 127.0.0.1:<%= dropsonde_port %>
 <% end %>
-<% if_p("logging.format.timestamp") do |format| %>
-log_timestamp_format: <%= format %>
-<% end -%>
+log_timestamp_format: "rfc3339"
 
 create:
   without_mount: <%= p("grootfs.skip_mount") %>

--- a/jobs/garden/templates/config/privileged_grootfs_config.yml.erb
+++ b/jobs/garden/templates/config/privileged_grootfs_config.yml.erb
@@ -6,7 +6,6 @@ log_level: <%= p('grootfs.log_level') %>
 <% if_p("grootfs.dropsonde_port") do |dropsonde_port| %>
 metron_endpoint: 127.0.0.1:<%= dropsonde_port %>
 <% end %>
-log_timestamp_format: "rfc3339"
 
 create:
   without_mount: <%= p("grootfs.skip_mount") %>

--- a/scripts/create-docker-container.bash
+++ b/scripts/create-docker-container.bash
@@ -3,7 +3,7 @@
 set -eu
 set -o pipefail
 
-THIS_FILE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+THIS_FILE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 WORKSPACE_DIR="${THIS_FILE_DIR}/../.."
 LOCATION="$WORKSPACE_DIR/artifacts"
 CI="${THIS_FILE_DIR}/../../wg-app-platform-runtime-ci"
@@ -21,9 +21,9 @@ else
   ARGS="${*}"
 fi
 
-pushd $REPO_PATH > /dev/null
+pushd $REPO_PATH >/dev/null
 bosh sync-blobs
-popd > /dev/null
+popd >/dev/null
 
 pushd "$CI/garden-runc-release/dockerfiles"
 LOCATION=${LOCATION} make
@@ -31,14 +31,14 @@ popd
 
 if [[ -f "${HOME}/.bash_functions" ]]; then
   . "${HOME}/.bash_functions"
-  export DOCKER_REGISTRY_USERNAME="$(gimme-secret-value-only dockerhub-tasruntime-username)"
-  export DOCKER_REGISTRY_PASSWORD="$(gimme-secret-value-only dockerhub-tasruntime-password)"
+  export DOCKER_REGISTRY_USERNAME="$(gimme-vault-secret-value-only dockerhub-tasruntime-username)"
+  export DOCKER_REGISTRY_PASSWORD="$(gimme-vault-secret-value-only dockerhub-tasruntime-password)"
 fi
 if [[ "${DOCKER_REGISTRY_USERNAME:-undefined}" == "undefined" || "${DOCKER_REGISTRY_PASSWORD:-undefined}" == "undefined" ]]; then
-  cat << EOF
+  cat <<EOF
   Run this script with DOCKER_REGISTRY_USERNAME, DOCKER_REGISTRY_PASSWORD env variables
 EOF
-exit 1
+  exit 1
 fi
 
 docker pull "${IMAGE}"
@@ -60,4 +60,3 @@ docker run -it \
   ${ARGS} \
   "${IMAGE}" \
   /bin/bash
-  

--- a/spec/jobs/garden_spec.rb
+++ b/spec/jobs/garden_spec.rb
@@ -207,10 +207,6 @@ describe 'garden' do
         expect(rendered_template['server']['port-pool-properties-path']).to eql('/var/vcap/data/garden/port-pool-props.json')
       end
 
-      it 'sets the time-format' do
-        expect(rendered_template['server']['time-format']).to eql('unix-epoch')
-      end
-
       it 'does not enable the container network metrics' do
         expect(rendered_template['server']['enable-container-network-metrics']).to eql(nil)
       end


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
cleanup logging time format property

Submodule updates:
https://github.com/cloudfoundry/guardian/pull/474
https://github.com/cloudfoundry/grootfs/pull/274


Backward Compatibility
---------------
Breaking Change? **No**

Test results:

```
Before:
{"timestamp":"1749498120.196136713","source":"grootfs","message":"grootfs.clean.unused-volumes.ending","log_level":1,"data":{"session":"1.2"}}
{"timestamp":"1749498120.196497440","source":"grootfs","message":"grootfs.clean.unused-volumes.starting","log_level":1,"data":{"session":"1.7"}}
{"timestamp":"1749498120.196600676","source":"grootfs","message":"grootfs.clean.unused-volumes.ending","log_level":1,"data":{"session":"1.7"}}
diego-cell/84bd3296-3007-4f75-bb58-971830674a7b:/var/vcap/data/sys/log/garden#

After:
{"timestamp":"2025-06-09T22:31:03.836903044Z","level":"info","source":"grootfs","message":"grootfs.clean.unused-volumes.starting","data":{"session":"1.9"}}
{"timestamp":"2025-06-09T22:31:03.837044786Z","level":"info","source":"grootfs","message":"grootfs.clean.unused-volumes.ending","data":{"session":"1.9"}}
diego-cell/84bd3296-3007-4f75-bb58-971830674a7b:/var/vcap/data/sys/log/garden# 


Before:
{"timestamp":"1749226046.191487551","source":"guardian","message":"guardian.list-containers.finished","log_level":1,"data":{"session":"24"}}
{"timestamp":"1749226059.601012707","source":"guardian","message":"guardian.api.garden-server.bulk_metrics.got-bulkmetrics","log_level":1,"data":{"handles":[],"session":"2.1.25"}}
compute/4cd7edd3-0f6a-4d28-a93f-b61c6d619d6f:/var/vcap/sys/log/garden#
After:
{"timestamp":"2025-06-09T22:33:12.218693127Z","level":"info","source":"guardian","message":"guardian.list-containers.finished","data":{"session":"70"}}
{"timestamp":"2025-06-09T22:33:17.870554627Z","level":"info","source":"guardian","message":"guardian.api.garden-server.bulk_metrics.got-bulkmetrics","data":{"handles":[],"session":"2.1.125"}}
diego-cell/84bd3296-3007-4f75-bb58-971830674a7b:/var/vcap/data/sys/log/garden



diego-cell/84bd3296-3007-4f75-bb58-971830674a7b:/var/vcap/data/sys/log/garden# cat pre-start.stdout.log
2025-06-09T12:54:30.383171403Z - running thresholder
2025-06-09T12:54:30.398119587Z - done

diego-cell/84bd3296-3007-4f75-bb58-971830674a7b:/var/vcap/data/sys/log/garden# cat post-start.stdout.log
2025-06-09T12:55:22.825108375Z: Pinging garden server...

Before:
diego-cell/84bd3296-3007-4f75-bb58-971830674a7b:/var/vcap/jobs/garden/config# cat * | grep unix
    time-format = unix-epoch
log_timestamp_format: unix-epoch
log_timestamp_format: unix-epoch

After:
diego-cell/84bd3296-3007-4f75-bb58-971830674a7b:/var/vcap/jobs/garden/config$ cat * | grep unix
diego-cell/84bd3296-3007-4f75-bb58-971830674a7b:/var/vcap/jobs/garden/config$ cat * | grep rfc



```