### PR TITLE
Remove old property: destroy_containers_on_start - garden-runc release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,7 @@ GEM
     thor (1.2.2)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-21
   x86_64-linux
 

--- a/docs/04-bpm-support.md
+++ b/docs/04-bpm-support.md
@@ -13,8 +13,7 @@ Since BPM isolates workloads, having an additional level of isolation via Garden
 ### Primary Properties
 Garden-runc-release’s BPM support is implemented primarily through two flags `bpm.enabled` and `garden.additional_bpm_volumes`.
 #### `bpm.enabled`
-The primary flag [`bpm.enabled`](https://github.com/cloudfoundry/garden-runc-release/blob/develop/jobs/garden/spec#L303-L305) within the Garden spec will allow Garden-runc-release to use BPM. When enabling this flag, use a measure of caution: The containers won't survive a restart of the garden job. This is why `garden.destroy_containers_on_start` should be set to avoid leaking container state.
-It’s default value is “false”
+The primary flag [`bpm.enabled`](https://github.com/cloudfoundry/garden-runc-release/blob/develop/jobs/garden/spec#L303-L305) within the Garden spec will allow Garden-runc-release to use BPM. 
 
 #### `garden.additional_bpm_volumes` 
 A secondary property [`garden.additional_bpm_volumes`](https://github.com/cloudfoundry/garden-runc-release/blob/develop/jobs/garden/spec#L157-L159), requires `bpm.enabled` to be enabled. This property allows an array of shared writable volumes which will be mounted into the BPM container. Submounts from all mount namespaces in a volume are visible in all containers that have the volume mounted in.
@@ -25,10 +24,6 @@ Its default value is left blank.
 In addition to the above primary properties, there are some secondary properties that have caveats when enabling BPM:
 #### `garden.experimental_use_containerd_mode_for_processes`
 When enabling [`garden.experimental_use_containerd_mode_for_processes`](https://github.com/cloudfoundry/garden-runc-release/blob/develop/jobs/garden/spec#L231-L233), please ensure you do NOT have `bpm.enabled` enabled. The two properties are incompatible with one another. The purpose of the property is to use Containerd for container process management. Must be used with containerd_mode also set to true. NOTE: cannot be used in combination with bpm
-By default it is disabled(set to false).
-
-#### `garden.destroy_containers_on_start`
-The property [`garden.destroy_containers_on_start`](https://github.com/cloudfoundry/garden-runc-release/blob/develop/jobs/garden/spec#L181-L183) is recommended when enabling bpm via `bpm.enabled`. This is recommend so that container state is not leaked and all containers managed by Garden-runc-release, are destroyed, recreated and managed within the confines of BPM’s isolation. 
 By default it is disabled(set to false).
 
 

--- a/docs/06-cpu-throttling.md
+++ b/docs/06-cpu-throttling.md
@@ -16,8 +16,6 @@ and this [video](https://youtu.be/vV87xmxKLeA).
 
 ## Enabling and disabling cpu-throttling
 
-Ensure you set the [destroy_containers_on_start](https://github.com/cloudfoundry/garden-runc-release/blob/42497fc3b1365210ffa9681acf97f3f7314bbd01/jobs/garden/spec#L171-L173) flag when changing this property, otherwise existing containers will be in the wrong part of the cgroup structure.
-
 ### cgroup structure
 
 When enabled, two extra cpu cgroup directories are inserted in the garden

--- a/jobs/garden-windows/spec
+++ b/jobs/garden-windows/spec
@@ -65,9 +65,6 @@ properties:
     description: "Maximum container capacity to advertise. It is not recommended to set this larger than 75."
     default: 75
 
-  garden.destroy_containers_on_start:
-    description: "If true, all existing containers will be destroyed any time the garden server starts up"
-    default: false
 
   garden.default_container_rootfs:
     description: "path to the rootfs to use when a container specifies no rootfs"

--- a/jobs/garden-windows/templates/garden_ctl.ps1.erb
+++ b/jobs/garden-windows/templates/garden_ctl.ps1.erb
@@ -62,9 +62,6 @@ C:\var\vcap\packages\guardian-windows\gdn.exe `
   <% if_p("garden.dropsonde.destination") do |destination| %> `
     --dropsonde-destination=<%= destination %> `
   <% end %> `
-  <% if p("garden.destroy_containers_on_start") %> `
-  --destroy-containers-on-startup `
-  <% end %> `
   <% if p("garden.cleanup_process_dirs_on_wait") == true %> `
   --cleanup-process-dirs-on-wait `
   <% end %>

--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -181,9 +181,6 @@ properties:
     description: "If true, container is not going to be limited in swap space. Should only be used if swap is disabled on the VM."
     default: false
 
-  garden.destroy_containers_on_start:
-    description: "If true, all existing containers will be destroyed any time the garden server starts up"
-    default: false
 
   garden.network_pool:
     description: "A CIDR subnet mask specifying the range of subnets available to be assigned to containers."

--- a/jobs/garden/templates/config/config.ini.erb
+++ b/jobs/garden/templates/config/config.ini.erb
@@ -83,9 +83,6 @@ parse_ip(p('garden.network_pool'), 'garden.network_pool')
 
 ; containers
   default-grace-time = <%= p("garden.default_container_grace_time") %>
-<% if p("garden.destroy_containers_on_start") -%>
-  destroy-containers-on-startup = true
-<% end -%>
 <% if_p("garden.max_containers") do |max_containers| -%>
   max-containers = <%= max_containers %>
 <% end -%>


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------

Remove old property: destroy_containers_on_start as it will be always true
https://github.com/cloudfoundry/guardian/pull/483

Test report:
https://ci.funtime.lol/builds/566047327 - observed failures on unrelated tests.

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
