### PR TITLE
Use default tar.exe shippped with OS

### DIFF
--- a/jobs/garden-windows/spec
+++ b/jobs/garden-windows/spec
@@ -59,7 +59,7 @@ properties:
 
   garden.tar_bin:
     description: "Path to tar binary"
-    default: "C:\\var\\vcap\\bosh\\bin\\tar.exe"
+    default: "C:\\Windows\\System32\\tar.exe"
 
   garden.max_containers:
     description: "Maximum container capacity to advertise. It is not recommended to set this larger than 75."


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Windows stemcells stoped using BSD tar.exe
(https://github.com/cloudfoundry/bosh-windows-stemcell-builder/commit/614bdc068f5f56357704c53ff81ef1a6a8b4486e) we need to update the release to be able to be compatible with latest version of windows stemcells


Backward Compatibility
---------------
Breaking Change? **No**
