### PR TITLE
Update containerd package to use thee binary distribution

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,7 +26,3 @@
 	path = src/garden-performance-acceptance-tests
 	url = https://github.com/cloudfoundry/garden-performance-acceptance-tests
 	branch = main
-[submodule "src/containerd"]
-	path = src/containerd
-	url = https://github.com/containerd/containerd
-	branch = release/2.0

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -10,6 +10,10 @@ busybox/busybox-1.36.1.tar.gz:
   size: 2524386
   object_id: dcbd055b-aa50-4729-522a-55f30dd57aef
   sha: sha256:68175336cdd42fecc2cd00851e9555fb2aebfe9f50d91ce8f9fb6708dba77110
+containerd/containerd-2.2.1-linux-amd64.tar.gz:
+  size: 35057737
+  object_id: 13a9a1da-ce82-45bc-62a8-c70bd3278a79
+  sha: sha256:f5d8e90ecb6c1c7e33ecddf8cc268a93b9e5b54e0e850320d765511d76624f41
 gperf/gperf-3.1.tar.gz:
   size: 1215925
   object_id: 756c90ec-175f-4b1a-482d-de2461421ea5

--- a/jobs/garden/templates/config/containerd.toml.erb
+++ b/jobs/garden/templates/config/containerd.toml.erb
@@ -2,6 +2,7 @@ version = 3
 root = '/var/vcap/data/containerd/root'
 state = '/var/vcap/sys/run/containerd/state'
 disabled_plugins = ['io.containerd.snapshotter.v1.aufs',
+  'io.containerd.snapshotter.v1.btrfs',
   'io.containerd.snapshotter.v1.devmapper',
   'io.containerd.snapshotter.v1.overlayfs',
   'io.containerd.snapshotter.v1.zfs',

--- a/packages/containerd/packaging
+++ b/packages/containerd/packaging
@@ -1,18 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-mkdir -p "${BOSH_INSTALL_TARGET}/src"
-mv * ${BOSH_INSTALL_TARGET}/src
-mv ${BOSH_INSTALL_TARGET}/src .
-
-source /var/vcap/packages/golang-*-linux/bosh/compile.env
-
 mkdir -p "${BOSH_INSTALL_TARGET}/bin"
-export GOBIN="${BOSH_INSTALL_TARGET}/bin"
 
-pushd src/containerd
-  BUILDTAGS=no_btrfs make ./bin/containerd
-  BUILDTAGS=no_btrfs make ./bin/containerd-shim-runc-v2
-  BUILDTAGS=no_btrfs make ./bin/ctr
-  cp -R bin "${BOSH_INSTALL_TARGET}"
-popd
+# tarball has its own bin/ directory
+tar -xzvf containerd/containerd-*-linux-amd64.tar.gz -C "${BOSH_INSTALL_TARGET}/"

--- a/packages/containerd/spec
+++ b/packages/containerd/spec
@@ -1,8 +1,7 @@
 ---
 name: containerd
 
-dependencies:
-  - golang-1.25-linux
+dependencies: []
 
 files:
-  - containerd/**/*
+  - containerd/*


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Containerd contains a symlink in its repo, which causes problems for us on windows concourse workers where they hang while streaming the volume from linux workers. The upstream distributions have the binaries we care about, and are statically linked.  There were no previously no ties between the versions of containerd used in guardian and the containerd binary compiled for use on the diego cells, and both were updated independently of eachother, so this doesn't make version management any worse than it already was. 


Backward Compatibility
---------------
Breaking Change? no