### PR TITLE
Update BusyBox references to 1.37.0 to fix CVE-2022-48174

### DIFF
--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -86,7 +86,7 @@ properties:
 
   garden.default_container_rootfs:
     description: "path to the rootfs to use when a container specifies no rootfs"
-    default: /var/vcap/packages/busybox/busybox-1.36.1.tar
+    default: /var/vcap/packages/busybox/busybox-1.37.0.tar
 
   garden.graph_cleanup_threshold_in_mb:
     description: "DEPRECATED in favour of grootfs.reserved_space_for_other_jobs_in_mb."

--- a/packages/busybox/packaging
+++ b/packages/busybox/packaging
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Busybox tarball created with:
-# <garden-runc-release>/scripts/create-busybox-tar.sh busybox:1.36.1 busybox
+# <garden-runc-release>/scripts/create-busybox-tar.sh busybox:1.37.0 busybox
 
 
 tgz_name="$(basename busybox/busybox-*.tar.gz)"

--- a/spec/jobs/garden_spec.rb
+++ b/spec/jobs/garden_spec.rb
@@ -72,7 +72,7 @@ describe 'garden' do
       end
 
       it 'sets the default container rootfs to busybox' do
-        expect(rendered_template['server']['default-rootfs']).to eq('/var/vcap/packages/busybox/busybox-1.36.1.tar')
+        expect(rendered_template['server']['default-rootfs']).to eq('/var/vcap/packages/busybox/busybox-1.37.0.tar')
       end
 
       it 'sets the runtime plugin to 0' do


### PR DESCRIPTION
Summary
---------------
This CVE addresses a high security vulnerability in golang versions below 1.24.11 and below 1.25.5 in their release line-ups. The garden-runc release uses Go 1.25.3 and hence it is affected by this vulnerability. The fix is available in 1.24.11 and 1.25.5. Here are more details about this CVE and Github links explaining the issue and the fix.

https://nvd.nist.gov/vuln/detail/CVE-2025-61729
https://github.com/golang/go/issues/76445
https://groups.google.com/g/golang-announce/c/8FJoBkPddm4?pli=1
https://github.com/golang/go/issues?q=milestone%3AGo1.25.5+label%3ACherryPickApproved
https://github.com/golang/go/issues/76461
https://go-review.googlesource.com/c/go/+/725920

Backward Compatibility
---------------
Breaking Change? No
