### PR TITLE
Add device cgroup rule flag for garden job

### DIFF
--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -202,6 +202,10 @@ properties:
     description: AppArmor profile to use for unprivileged container processes
     default: garden-default
 
+  garden.device_cgroup_rules:
+    description: Device cgroup rules that will be applied to privileged containers. By default loop devices are allowed for privileged containers.
+    default: ["b 7:* rwm", "c 10:237 rwm"]
+
   # We believe this defaults to false to help concourse: https://github.com/cloudfoundry/garden-runc-release/releases/tag/v1.5.0
   # For diego/cf, this should be set to true
   garden.cleanup_process_dirs_on_wait:

--- a/jobs/garden/templates/config/config.ini.erb
+++ b/jobs/garden/templates/config/config.ini.erb
@@ -122,6 +122,9 @@ parse_ip(p('garden.network_pool'), 'garden.network_pool')
   <% end -%>
   tcp-retries2 = <%= retries2 %>
 <% end -%>
+<% p("garden.device_cgroup_rules").each do |rule| -%>
+  device-cgroup-rule = "<%= rule %>"
+<% end -%>
 
 ; image and rootfs
   default-rootfs = <%= p("garden.default_container_rootfs") %>

--- a/spec/jobs/garden_spec.rb
+++ b/spec/jobs/garden_spec.rb
@@ -95,6 +95,10 @@ describe 'garden' do
         expect(rendered_template['server']['cpu-entitlement-per-share']).to eql(0)
       end
 
+      it 'sets the default device cgroup rules' do
+        expect(rendered_template['server']['device-cgroup-rule']).to eql(['"b 7:* rwm"', '"c 10:237 rwm"'])
+      end
+
       context 'cpu throttling' do
         context 'by default' do
           it 'sets the enable cpu throttling per share to false' do


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Expose device-cgroup-rule flag in garden-runc-release that configures [DeviceCgroupRule](https://github.com/cloudfoundry/guardian/blob/249a41642042a647238351dcab839198e4608fbf/guardiancmd/command.go#L110) in guardian. This flag provides a list of cgroup device rule to allow devices in privileged containers.

By default, loop devices should be open for privileged containers since this is what is expected for privileged containers and this is how it works with cgroups v1.

Backward Compatibility
---------------
Breaking Change? **No**

