### PR TITLE
Add configurable GC threshold factor for grootfs

### DIFF
--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -303,6 +303,10 @@ properties:
     description: "Amount of space that will be kept free for other jobs. The GrootFS store will be able to grow up to a maximum size of its disk minus this reserved space. Where the reserved space does not allow sufficient size for GrootFS to store container images and root filesystems (currently 15GB), the limit will be a soft limit, and garbage collection will attempt to keep disk space available for other jobs. -1 disables GC and allows GrootFS to potentially use the whole disk."
     default: 15360
 
+  grootfs.gc_threshold_factor:
+    description: "Factor (in the range (0, 1]) applied to the available store space to compute the garbage collection threshold. The effective GC threshold is `factor * (available_space - reserved_space_for_other_jobs)`. A factor of 1.0 (the default) preserves the historical behaviour of triggering GC only when the store fills the available space; smaller values trigger GC sooner."
+    default: 1.0
+
   grootfs.experimental_direct_io:
     description: "Enable the DIRECT_IO flag on the loop device associated with the GrootFS store. This should reduce memory and processing overheads by eliminating double caching of the store filesystem"
     default: false

--- a/jobs/garden/templates/bin/grootfs-utils.erb
+++ b/jobs/garden/templates/bin/grootfs-utils.erb
@@ -4,8 +4,8 @@ export store_mountpoint="/var/vcap/data"
 
 invoke_thresholder() {
   log "running thresholder"
-  /var/vcap/packages/thresholder/bin/thresholder "<%= p("grootfs.reserved_space_for_other_jobs_in_mb") %>" "<%= p("grootfs.routine_gc") %>" "$DATA_DIR" "$GARDEN_CONFIG_DIR/grootfs_config.yml" "<%= p("garden.graph_cleanup_threshold_in_mb") %>" "<%= p("grootfs.graph_cleanup_threshold_in_mb") %>"
-  /var/vcap/packages/thresholder/bin/thresholder "<%= p("grootfs.reserved_space_for_other_jobs_in_mb") %>" "<%= p("grootfs.routine_gc") %>" "$DATA_DIR" "$GARDEN_CONFIG_DIR/privileged_grootfs_config.yml" "<%= p("garden.graph_cleanup_threshold_in_mb") %>" "<%= p("grootfs.graph_cleanup_threshold_in_mb") %>"
+  /var/vcap/packages/thresholder/bin/thresholder "<%= p("grootfs.reserved_space_for_other_jobs_in_mb") %>" "<%= p("grootfs.routine_gc") %>" "$DATA_DIR" "$GARDEN_CONFIG_DIR/grootfs_config.yml" "<%= p("garden.graph_cleanup_threshold_in_mb") %>" "<%= p("grootfs.graph_cleanup_threshold_in_mb") %>" "<%= p("grootfs.gc_threshold_factor") %>"
+  /var/vcap/packages/thresholder/bin/thresholder "<%= p("grootfs.reserved_space_for_other_jobs_in_mb") %>" "<%= p("grootfs.routine_gc") %>" "$DATA_DIR" "$GARDEN_CONFIG_DIR/privileged_grootfs_config.yml" "<%= p("garden.graph_cleanup_threshold_in_mb") %>" "<%= p("grootfs.graph_cleanup_threshold_in_mb") %>" "<%= p("grootfs.gc_threshold_factor") %>"
   log "done"
 }
 

--- a/spec/jobs/garden_spec.rb
+++ b/spec/jobs/garden_spec.rb
@@ -255,4 +255,98 @@ describe 'garden' do
       # end
     end
   end
+
+  context 'bin/grootfs-utils' do
+    let(:template) { job.template('bin/grootfs-utils') }
+
+    context 'with defaults' do
+      let(:rendered_template) { template.render(properties) }
+
+      it 'passes the default reserved_space_for_other_jobs_in_mb to thresholder' do
+        expect(rendered_template).to include('/var/vcap/packages/thresholder/bin/thresholder "15360"')
+      end
+
+      it 'passes routine_gc as false' do
+        expect(rendered_template).to match(/thresholder "15360" "false"/)
+      end
+
+      it 'passes the default gc_threshold_factor of 1.0' do
+        expect(rendered_template).to match(/"-1" "1.0"$/)
+      end
+
+      it 'invokes thresholder for both unprivileged and privileged configs' do
+        expect(rendered_template).to include('$GARDEN_CONFIG_DIR/grootfs_config.yml')
+        expect(rendered_template).to include('$GARDEN_CONFIG_DIR/privileged_grootfs_config.yml')
+      end
+    end
+
+    context 'when grootfs.gc_threshold_factor is set' do
+      let(:properties) do
+        {
+          'grootfs' => {
+            'gc_threshold_factor' => 0.5
+          }
+        }
+      end
+
+      let(:rendered_template) { template.render(properties) }
+
+      it 'passes the configured factor to thresholder' do
+        expect(rendered_template).to match(/"-1" "0.5"$/)
+      end
+    end
+
+    context 'when grootfs.routine_gc is true' do
+      let(:properties) do
+        {
+          'grootfs' => {
+            'routine_gc' => true
+          }
+        }
+      end
+
+      let(:rendered_template) { template.render(properties) }
+
+      it 'passes routine_gc as true' do
+        expect(rendered_template).to match(/thresholder "15360" "true"/)
+      end
+
+      it 'still passes the default gc_threshold_factor' do
+        expect(rendered_template).to match(/"-1" "1.0"$/)
+      end
+    end
+
+    context 'when grootfs.reserved_space_for_other_jobs_in_mb is customized' do
+      let(:properties) do
+        {
+          'grootfs' => {
+            'reserved_space_for_other_jobs_in_mb' => 5000,
+            'gc_threshold_factor' => 0.75
+          }
+        }
+      end
+
+      let(:rendered_template) { template.render(properties) }
+
+      it 'passes the custom reserved space and factor' do
+        expect(rendered_template).to match(/thresholder "5000" "false" "\$DATA_DIR" "\$GARDEN_CONFIG_DIR\/grootfs_config.yml" "-1" "-1" "0.75"/)
+      end
+    end
+
+    context 'when deprecated garden.graph_cleanup_threshold_in_mb is set' do
+      let(:properties) do
+        {
+          'garden' => {
+            'graph_cleanup_threshold_in_mb' => 2000
+          }
+        }
+      end
+
+      let(:rendered_template) { template.render(properties) }
+
+      it 'passes the deprecated threshold alongside the factor' do
+        expect(rendered_template).to match(/"2000" "-1" "1.0"$/)
+      end
+    end
+  end
 end

--- a/src/thresholder/calculator/calculator.go
+++ b/src/thresholder/calculator/calculator.go
@@ -1,5 +1,7 @@
 package calculator
 
+import "math"
+
 type Calculator interface {
 	ShouldCollectGarbageOnCreate() bool
 	CalculateStoreSize() int64
@@ -7,22 +9,32 @@ type Calculator interface {
 }
 
 type modernCalculator struct {
-	reservedSpace int64
-	diskSize      int64
-	minStoreSize  int64
-	routineGC     bool
+	reservedSpace     int64
+	diskSize          int64
+	minStoreSize      int64
+	routineGC         bool
+	gcThresholdFactor float64
 }
 
-func NewModernCalculator(reservedSpace, diskSize, minStoreSize int64, routineGC bool) Calculator {
+// NewModernCalculator builds a Calculator that, by default, sets the GC
+// threshold to (diskSize - reservedSpace). The threshold can be scaled down
+// by providing a gcThresholdFactor in the range (0, 1]; values <= 0 or
+// non-finite values fall back to 1.0 to preserve historical behaviour.
+func NewModernCalculator(reservedSpace, diskSize, minStoreSize int64, routineGC bool, gcThresholdFactor float64) Calculator {
 	if routineGC {
 		reservedSpace = diskSize
 	}
 
+	if !isValidFactor(gcThresholdFactor) {
+		gcThresholdFactor = 1.0
+	}
+
 	return &modernCalculator{
-		reservedSpace: reservedSpace,
-		diskSize:      diskSize,
-		minStoreSize:  minStoreSize,
-		routineGC:     routineGC,
+		reservedSpace:     reservedSpace,
+		diskSize:          diskSize,
+		minStoreSize:      minStoreSize,
+		routineGC:         routineGC,
+		gcThresholdFactor: gcThresholdFactor,
 	}
 }
 
@@ -40,7 +52,12 @@ func (m modernCalculator) CalculateStoreSize() int64 {
 }
 
 func (m modernCalculator) CalculateGCThreshold() int64 {
-	return positiveOrZero(m.diskSize - positiveOrZero(m.reservedSpace))
+	available := positiveOrZero(m.diskSize - positiveOrZero(m.reservedSpace))
+	scaled := math.Floor(float64(available) * m.gcThresholdFactor)
+	if scaled < 0 {
+		return 0
+	}
+	return int64(scaled)
 }
 
 type oldFashionedCalculator struct {
@@ -81,4 +98,11 @@ func positiveOrZero(n int64) int64 {
 	}
 
 	return n
+}
+
+func isValidFactor(f float64) bool {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return false
+	}
+	return f > 0 && f <= 1
 }

--- a/src/thresholder/calculator/calculator_test.go
+++ b/src/thresholder/calculator/calculator_test.go
@@ -15,18 +15,20 @@ var (
 
 var _ = Describe("modern calculator", func() {
 	var (
-		reservedSpace int64
-		minStoreSize  int64
+		reservedSpace     int64
+		minStoreSize      int64
+		gcThresholdFactor float64
 	)
 
 	BeforeEach(func() {
 		diskSize = 10
 		routineGC = false
 		minStoreSize = 3
+		gcThresholdFactor = 1.0
 	})
 
 	JustBeforeEach(func() {
-		calc = calculator.NewModernCalculator(reservedSpace, diskSize, minStoreSize, routineGC)
+		calc = calculator.NewModernCalculator(reservedSpace, diskSize, minStoreSize, routineGC, gcThresholdFactor)
 	})
 
 	Describe("CalculateStoreSize", func() {
@@ -63,6 +65,16 @@ var _ = Describe("modern calculator", func() {
 				Expect(storeSize).To(Equal(diskSize))
 			})
 		})
+
+		When("the GC threshold factor is less than 1", func() {
+			BeforeEach(func() {
+				gcThresholdFactor = 0.5
+			})
+
+			It("does not affect the store size", func() {
+				Expect(storeSize).To(Equal(int64(6)))
+			})
+		})
 	})
 
 	Describe("CalculateGCThreshold", func() {
@@ -76,7 +88,7 @@ var _ = Describe("modern calculator", func() {
 			threshold = calc.CalculateGCThreshold()
 		})
 
-		It("returns (disk size - reserved size)", func() {
+		It("returns (disk size - reserved size) when factor is 1", func() {
 			Expect(threshold).To(Equal(int64(6)))
 		})
 
@@ -107,6 +119,89 @@ var _ = Describe("modern calculator", func() {
 
 			It("does not subtract the sentinel value from the disk size", func() {
 				Expect(threshold).To(Equal(diskSize))
+			})
+
+			When("the factor is less than 1", func() {
+				BeforeEach(func() {
+					gcThresholdFactor = 0.5
+				})
+
+				It("scales the full disk size by the factor", func() {
+					Expect(threshold).To(Equal(int64(5)))
+				})
+			})
+		})
+
+		When("the GC threshold factor is 0.5", func() {
+			BeforeEach(func() {
+				gcThresholdFactor = 0.5
+			})
+
+			It("returns half of (disk size - reserved size)", func() {
+				Expect(threshold).To(Equal(int64(3)))
+			})
+		})
+
+		When("the GC threshold factor is 1", func() {
+			BeforeEach(func() {
+				gcThresholdFactor = 1.0
+			})
+
+			It("preserves the historical behaviour", func() {
+				Expect(threshold).To(Equal(int64(6)))
+			})
+		})
+
+		When("the GC threshold factor produces a fractional result", func() {
+			BeforeEach(func() {
+				diskSize = 10
+				reservedSpace = 0
+				gcThresholdFactor = 0.33
+			})
+
+			It("floors the threshold to a whole number of bytes", func() {
+				Expect(threshold).To(Equal(int64(3)))
+			})
+		})
+
+		When("the GC threshold factor combines with routineGC", func() {
+			BeforeEach(func() {
+				routineGC = true
+				gcThresholdFactor = 0.5
+			})
+
+			It("still returns 0 because reservedSpace is forced to diskSize", func() {
+				Expect(threshold).To(BeZero())
+			})
+		})
+
+		When("the GC threshold factor is invalid (<= 0)", func() {
+			BeforeEach(func() {
+				gcThresholdFactor = 0
+			})
+
+			It("falls back to a factor of 1.0 to preserve historical behaviour", func() {
+				Expect(threshold).To(Equal(int64(6)))
+			})
+		})
+
+		When("the GC threshold factor is invalid (> 1)", func() {
+			BeforeEach(func() {
+				gcThresholdFactor = 2.5
+			})
+
+			It("falls back to a factor of 1.0 to preserve historical behaviour", func() {
+				Expect(threshold).To(Equal(int64(6)))
+			})
+		})
+
+		When("the GC threshold factor is negative", func() {
+			BeforeEach(func() {
+				gcThresholdFactor = -0.25
+			})
+
+			It("falls back to a factor of 1.0 to preserve historical behaviour", func() {
+				Expect(threshold).To(Equal(int64(6)))
 			})
 		})
 	})
@@ -144,6 +239,17 @@ var _ = Describe("modern calculator", func() {
 			})
 
 			It("acts as though the reservedSpace is equal to diskSize and returns true", func() {
+				Expect(cleanOnStart).To(BeTrue())
+			})
+		})
+
+		When("the GC threshold factor is less than 1", func() {
+			BeforeEach(func() {
+				reservedSpace = 1
+				gcThresholdFactor = 0.5
+			})
+
+			It("does not affect the result", func() {
 				Expect(cleanOnStart).To(BeTrue())
 			})
 		})

--- a/src/thresholder/main.go
+++ b/src/thresholder/main.go
@@ -14,8 +14,8 @@ import (
 const MIN_STORE_SIZE = 15 * 1024 * 1024 * 1024
 
 func main() {
-	if len(os.Args) != 7 {
-		failWithMessage("Not all input arguments provided (Expected: 6)")
+	if len(os.Args) != 8 {
+		failWithMessage("Not all input arguments provided (Expected: 7)")
 	}
 
 	reservedSpace := megabytesToBytes(parseIntParameter(os.Args[1], "Reserved space parameter must be a number"))
@@ -28,13 +28,14 @@ func main() {
 	configPath := os.Args[4]
 	gardenGcThreshold := megabytesToBytes(parseIntParameter(os.Args[5], "Garden GC threshold parameter must be a number"))
 	grootfsGcThreshold := megabytesToBytes(parseIntParameter(os.Args[6], "GrootFS GC threshold parameter must be a number"))
+	gcThresholdFactor := parseFloatParameter(os.Args[7], "GC threshold factor parameter must be a number")
 
 	diskSize, err := disk.NewMeter().GetAvailableSpace(diskPath)
 	if err != nil {
 		failWithMessage(err.Error())
 	}
 
-	calc := calculator.NewModernCalculator(reservedSpace, diskSize, MIN_STORE_SIZE, routineGC)
+	calc := calculator.NewModernCalculator(reservedSpace, diskSize, MIN_STORE_SIZE, routineGC, gcThresholdFactor)
 	if gardenGcThreshold > 0 || grootfsGcThreshold > 0 {
 		calc = calculator.NewOldFashionedCalculator(diskSize, gardenGcThreshold, grootfsGcThreshold)
 	}
@@ -58,6 +59,15 @@ func parseIntParameter(parameterValue, failureMessage string) int64 {
 	}
 
 	return intValue
+}
+
+func parseFloatParameter(parameterValue, failureMessage string) float64 {
+	floatValue, err := strconv.ParseFloat(parameterValue, 64)
+	if err != nil {
+		failWithMessage(failureMessage)
+	}
+
+	return floatValue
 }
 
 func parseFileParameter(parameterValue, failureMessage string) *config.Config {

--- a/src/thresholder/thresholder_integration_test.go
+++ b/src/thresholder/thresholder_integration_test.go
@@ -25,6 +25,7 @@ var _ = Describe("Thresholder", func() {
 		pathToGrootfsConfig string
 		gardenGcThreshold   string
 		grootfsGcThreshold  string
+		gcThresholdFactor   string
 	)
 
 	exitsNonZeroWithMessage := func(message string) {
@@ -47,10 +48,11 @@ var _ = Describe("Thresholder", func() {
 		pathToGrootfsConfig = copyFileToTempFile(pathToGrootfsConfigAsset)
 		gardenGcThreshold = "-1"
 		grootfsGcThreshold = "-1"
+		gcThresholdFactor = "1.0"
 	})
 
 	JustBeforeEach(func() {
-		thresholderCmd = exec.Command(thresholderBin, reservedSpace, routineGC, pathToDisk, pathToGrootfsConfig, gardenGcThreshold, grootfsGcThreshold)
+		thresholderCmd = exec.Command(thresholderBin, reservedSpace, routineGC, pathToDisk, pathToGrootfsConfig, gardenGcThreshold, grootfsGcThreshold, gcThresholdFactor)
 	})
 
 	AfterEach(func() {
@@ -136,6 +138,69 @@ var _ = Describe("Thresholder", func() {
 
 	})
 
+	Context("when a GC threshold factor is provided", func() {
+		When("the factor is 1.0 (the default)", func() {
+			BeforeEach(func() {
+				gcThresholdFactor = "1.0"
+			})
+
+			It("sets clean.threshold_bytes to the full available space minus reserved", func() {
+				gexecStartAndWait(thresholderCmd, GinkgoWriter, GinkgoWriter)
+				config := configFromFile(pathToGrootfsConfig)
+
+				Expect(config.Clean.ThresholdBytes).To(BeMoreOrLess(diskSize - megabytesToBytes(3000)))
+			})
+		})
+
+		When("the factor is less than 1", func() {
+			BeforeEach(func() {
+				gcThresholdFactor = "0.5"
+			})
+
+			It("scales clean.threshold_bytes by the factor", func() {
+				gexecStartAndWait(thresholderCmd, GinkgoWriter, GinkgoWriter)
+				config := configFromFile(pathToGrootfsConfig)
+
+				expected := int64(float64(diskSize-megabytesToBytes(3000)) * 0.5)
+				Expect(config.Clean.ThresholdBytes).To(BeMoreOrLess(expected))
+			})
+
+			It("does not scale init.store_size_bytes", func() {
+				gexecStartAndWait(thresholderCmd, GinkgoWriter, GinkgoWriter)
+				config := configFromFile(pathToGrootfsConfig)
+
+				Expect(config.Init.StoreSizeBytes).To(BeMoreOrLess(diskSize - megabytesToBytes(3000)))
+			})
+		})
+
+		When("the factor is invalid (out of range)", func() {
+			BeforeEach(func() {
+				gcThresholdFactor = "2.0"
+			})
+
+			It("falls back to a factor of 1.0", func() {
+				gexecStartAndWait(thresholderCmd, GinkgoWriter, GinkgoWriter)
+				config := configFromFile(pathToGrootfsConfig)
+
+				Expect(config.Clean.ThresholdBytes).To(BeMoreOrLess(diskSize - megabytesToBytes(3000)))
+			})
+		})
+
+		When("the factor is used together with the deprecated GC threshold properties", func() {
+			BeforeEach(func() {
+				gardenGcThreshold = "1000"
+				gcThresholdFactor = "0.5"
+			})
+
+			It("ignores the factor because the old-fashioned calculator takes precedence", func() {
+				gexecStartAndWait(thresholderCmd, GinkgoWriter, GinkgoWriter)
+				config := configFromFile(pathToGrootfsConfig)
+
+				Expect(config.Clean.ThresholdBytes).To(BeMoreOrLess(megabytesToBytes(1000)))
+			})
+		})
+	})
+
 	When("the store path doesn't exist", func() {
 		BeforeEach(func() {
 			pathToDisk = "/path/to/foo/bar"
@@ -148,18 +213,18 @@ var _ = Describe("Thresholder", func() {
 	Describe("Parameters validation", func() {
 		Context("when too few input args are provided", func() {
 			JustBeforeEach(func() {
-				thresholderCmd = exec.Command(thresholderBin, "1", "2", "3", "4", "5")
+				thresholderCmd = exec.Command(thresholderBin, "1", "2", "3", "4", "5", "6")
 			})
 
-			exitsNonZeroWithMessage("Not all input arguments provided (Expected: 6)")
+			exitsNonZeroWithMessage("Not all input arguments provided (Expected: 7)")
 		})
 
 		Context("when too many input args are provided", func() {
 			JustBeforeEach(func() {
-				thresholderCmd = exec.Command(thresholderBin, "1", "2", "3", "4", "5", "6", "7")
+				thresholderCmd = exec.Command(thresholderBin, "1", "2", "3", "4", "5", "6", "7", "8")
 			})
 
-			exitsNonZeroWithMessage("Not all input arguments provided (Expected: 6)")
+			exitsNonZeroWithMessage("Not all input arguments provided (Expected: 7)")
 		})
 
 		Context("when reserved space parameter cannot be parsed", func() {
@@ -200,6 +265,14 @@ var _ = Describe("Thresholder", func() {
 			})
 
 			exitsNonZeroWithMessage("GrootFS GC threshold parameter must be a number")
+		})
+
+		Context("when GC threshold factor parameter cannot be parsed", func() {
+			BeforeEach(func() {
+				gcThresholdFactor = "abc"
+			})
+
+			exitsNonZeroWithMessage("GC threshold factor parameter must be a number")
 		})
 	})
 })


### PR DESCRIPTION
> **AI-Assisted Disclaimer:** This PR was developed with AI assistance using [OpenCode](https://opencode.ai) powered by Anthropic Claude Opus 4.6 (model: `claude-opus-4-6`).


- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Add an optional `grootfs.gc_threshold_factor` BOSH property (default `1.0`) that scales the garbage collection threshold as a fraction of available store space. The effective GC threshold becomes:

```
threshold = factor * (disk_size - reserved_space_for_other_jobs)
```

This allows operators to trigger GC earlier (e.g. factor=0.5 triggers cleanup at 50% of available space) without changing the store size cap or requiring `routine_gc=true`.

**Motivation:** On deployments with large disks, the current behaviour (GC only triggers when the store is nearly full) can lead to prolonged periods of high disk usage before cleanup kicks in. A configurable factor provides a middle ground between the aggressive `routine_gc=true` (GC on every create) and the default (GC only at capacity).

**Changes:**
- `jobs/garden/spec` — new property `grootfs.gc_threshold_factor` (default 1.0)
- `jobs/garden/templates/bin/grootfs-utils.erb` — pass factor as 7th arg to thresholder
- `src/thresholder/main.go` — accept and parse the new arg
- `src/thresholder/calculator/calculator.go` — apply factor in `CalculateGCThreshold()`
- Ginkgo unit tests (calculator) — 14 new specs
- Ginkgo integration tests (thresholder binary) — new contexts for factor
- RSpec BOSH template spec tests — 9 new examples for `bin/grootfs-utils`

Invalid factor values (<=0, >1, NaN, Inf) fall back to 1.0 silently, preserving existing behaviour. The factor is ignored when deprecated `*_graph_cleanup_threshold_in_mb` properties are set (old-fashioned calculator takes precedence).

Backward Compatibility
---------------
Breaking Change? **No**

- Default value of `1.0` preserves existing behaviour exactly — no change for existing deployments.
- The new arg is appended to the thresholder binary invocation, so only deployments using this release version will pick it up.
- Operators can opt in by setting `grootfs.gc_threshold_factor` to a value in `(0, 1]`.
