### PR TITLE
Add per-container io.max throttling support (cgroups v2)

### DIFF
--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -85,16 +85,36 @@ properties:
     default: 0
 
   garden.container_io_max_read_bps:
-    description: "Per-container read bytes/s limit (cgroups v2 io.max rbps). 0 = unlimited. Only effective on cgroups v2 (Noble stemcells)."
+    description: |
+      Per-container read bytes/s limit (cgroups v2 io.max rbps). 0 = unlimited.
+      Only effective on cgroups v2 (Noble stemcells).
+      To choose a value: benchmark the disk's raw read throughput (e.g. fio --rw=read --bs=1m --direct=1)
+      and set a fraction that prevents a single container from saturating the disk.
+      Monitor io.stat or container diskio metrics to fine-tune.
     default: 0
   garden.container_io_max_write_bps:
-    description: "Per-container write bytes/s limit (cgroups v2 io.max wbps). 0 = unlimited. Only effective on cgroups v2 (Noble stemcells)."
+    description: |
+      Per-container write bytes/s limit (cgroups v2 io.max wbps). 0 = unlimited.
+      Only effective on cgroups v2 (Noble stemcells).
+      To choose a value: benchmark the disk's raw write throughput (e.g. fio --rw=write --bs=1m --direct=1)
+      and set a fraction that prevents a single container from saturating the disk.
+      Monitor io.stat or container diskio metrics to fine-tune.
     default: 0
   garden.container_io_max_read_iops:
-    description: "Per-container read IOPS limit (cgroups v2 io.max riops). 0 = unlimited. Only effective on cgroups v2 (Noble stemcells)."
+    description: |
+      Per-container read IOPS limit (cgroups v2 io.max riops). 0 = unlimited.
+      Only effective on cgroups v2 (Noble stemcells).
+      To choose a value: benchmark the disk's raw read IOPS (e.g. fio --rw=randread --bs=4k --direct=1)
+      and set a fraction that prevents a single container from saturating the disk.
+      Monitor io.stat or container diskio metrics to fine-tune.
     default: 0
   garden.container_io_max_write_iops:
-    description: "Per-container write IOPS limit (cgroups v2 io.max wiops). 0 = unlimited. Only effective on cgroups v2 (Noble stemcells)."
+    description: |
+      Per-container write IOPS limit (cgroups v2 io.max wiops). 0 = unlimited.
+      Only effective on cgroups v2 (Noble stemcells).
+      To choose a value: benchmark the disk's raw write IOPS (e.g. fio --rw=randwrite --bs=4k --direct=1)
+      and set a fraction that prevents a single container from saturating the disk.
+      Monitor io.stat or container diskio metrics to fine-tune.
     default: 0
 
   garden.default_container_rootfs:

--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -84,6 +84,19 @@ properties:
     description: "default blkio.weight value for containers. Valid values are 0 (use system default), or 10 - 1000."
     default: 0
 
+  garden.container_io_max_read_bps:
+    description: "Per-container read bytes/s limit (cgroups v2 io.max rbps). 0 = unlimited. Only effective on cgroups v2 (Noble stemcells)."
+    default: 0
+  garden.container_io_max_write_bps:
+    description: "Per-container write bytes/s limit (cgroups v2 io.max wbps). 0 = unlimited. Only effective on cgroups v2 (Noble stemcells)."
+    default: 0
+  garden.container_io_max_read_iops:
+    description: "Per-container read IOPS limit (cgroups v2 io.max riops). 0 = unlimited. Only effective on cgroups v2 (Noble stemcells)."
+    default: 0
+  garden.container_io_max_write_iops:
+    description: "Per-container write IOPS limit (cgroups v2 io.max wiops). 0 = unlimited. Only effective on cgroups v2 (Noble stemcells)."
+    default: 0
+
   garden.default_container_rootfs:
     description: "path to the rootfs to use when a container specifies no rootfs"
     default: /var/vcap/packages/busybox/busybox-1.37.0.tar

--- a/jobs/garden/templates/config/config.ini.erb
+++ b/jobs/garden/templates/config/config.ini.erb
@@ -209,6 +209,12 @@ parse_ip(p('garden.network_pool'), 'garden.network_pool')
 
 ; resource limiting
   default-container-blockio-weight = <%= p("garden.default_container_blockio_weight") %>
+<% if p("garden.container_io_max_read_bps") > 0 || p("garden.container_io_max_write_bps") > 0 || p("garden.container_io_max_read_iops") > 0 || p("garden.container_io_max_write_iops") > 0 -%>
+  container-io-max-read-bps = <%= p("garden.container_io_max_read_bps") %>
+  container-io-max-write-bps = <%= p("garden.container_io_max_write_bps") %>
+  container-io-max-read-iops = <%= p("garden.container_io_max_read_iops") %>
+  container-io-max-write-iops = <%= p("garden.container_io_max_write_iops") %>
+<% end -%>
 <% if_p("garden.cpu_quota_per_share_in_us") do |quota_per_share| -%>
   cpu-quota-per-share = <%= quota_per_share %>
 <% end -%>

--- a/spec/jobs/garden_spec.rb
+++ b/spec/jobs/garden_spec.rb
@@ -67,8 +67,15 @@ describe 'garden' do
         expect(rendered_template['server']['default-grace-time']).to eql(0)
       end
 
-      it 'sets the default container blockio wait to 0' do
+      it 'sets the default container blockio weight to 0' do
         expect(rendered_template['server']['default-container-blockio-weight']).to eql(0)
+      end
+
+      it 'does not render io-max properties when defaults are 0' do
+        expect(rendered_template['server']['container-io-max-read-bps']).to eql(nil)
+        expect(rendered_template['server']['container-io-max-write-bps']).to eql(nil)
+        expect(rendered_template['server']['container-io-max-read-iops']).to eql(nil)
+        expect(rendered_template['server']['container-io-max-write-iops']).to eql(nil)
       end
 
       it 'sets the default container rootfs to busybox' do
@@ -195,6 +202,58 @@ describe 'garden' do
               error_msg = 'garden.cpu_throttling_check_interval should be a positive integer'
               expect { rendered_template }.to raise_error(error_msg)
             end
+          end
+        end
+      end
+
+      context 'container io.max throttling' do
+        context 'when all io_max properties are set' do
+          let(:properties) {
+            {
+              'garden' => {
+                'container_io_max_read_bps' => 59768832,
+                'container_io_max_write_bps' => 59768832,
+                'container_io_max_read_iops' => 900,
+                'container_io_max_write_iops' => 900
+              }
+            }
+          }
+
+          it 'renders container-io-max-read-bps' do
+            expect(rendered_template['server']['container-io-max-read-bps']).to eql(59768832)
+          end
+
+          it 'renders container-io-max-write-bps' do
+            expect(rendered_template['server']['container-io-max-write-bps']).to eql(59768832)
+          end
+
+          it 'renders container-io-max-read-iops' do
+            expect(rendered_template['server']['container-io-max-read-iops']).to eql(900)
+          end
+
+          it 'renders container-io-max-write-iops' do
+            expect(rendered_template['server']['container-io-max-write-iops']).to eql(900)
+          end
+        end
+
+        context 'when only bps properties are set' do
+          let(:properties) {
+            {
+              'garden' => {
+                'container_io_max_read_bps' => 104857600,
+                'container_io_max_write_bps' => 52428800
+              }
+            }
+          }
+
+          it 'renders bps values' do
+            expect(rendered_template['server']['container-io-max-read-bps']).to eql(104857600)
+            expect(rendered_template['server']['container-io-max-write-bps']).to eql(52428800)
+          end
+
+          it 'renders iops as 0' do
+            expect(rendered_template['server']['container-io-max-read-iops']).to eql(0)
+            expect(rendered_template['server']['container-io-max-write-iops']).to eql(0)
           end
         end
       end


### PR DESCRIPTION
Generated with AI assistance.

Adds BOSH properties and guardian flags to configure per-container disk I/O limits via cgroups v2 io.max. Only effective on Noble stemcells (cgroups v2); silently skipped on Jammy (cgroups v1) and Windows.

## Summary

  Adds 4 BOSH properties to configure per-container disk I/O limits via cgroups v2 `io.max`.

  ## Properties

  | Property | Default | Description |
  |----------|---------|-------------|
  | `garden.container_io_max_read_bps` | 0 | Per-container read bytes/s limit |
  | `garden.container_io_max_write_bps` | 0 | Per-container write bytes/s limit |
  | `garden.container_io_max_read_iops` | 0 | Per-container read IOPS limit |
  | `garden.container_io_max_write_iops` | 0 | Per-container write IOPS limit |

  All default to 0 (unlimited/disabled). Only effective on Noble stemcells (cgroups v2).

  ## Changes

  - `jobs/garden/spec`: 4 new properties
  - `jobs/garden/templates/config/config.ini.erb`: Conditional config block (only emitted when any value > 0)

  ## Companion PR

  guardian: https://github.com/cloudfoundry/guardian/compare/main...vpetrinski:guardian:feature/io-max-throttling

  ## Tested

  Custom dev release (9.0.5.dev) deployed on Noble cell. All new containers receive io.max limits at creation. App startup unaffected.
