### PR TITLE
Disable runc libpathrs build tag for static compile

### DIFF
--- a/packages/runc/packaging
+++ b/packages/runc/packaging
@@ -16,6 +16,10 @@ mkdir -p "${BOSH_INSTALL_TARGET}/bin"
 export GOBIN="${BOSH_INSTALL_TARGET}/bin"
 
 pushd src/guardian/vendor/github.com/opencontainers/runc
+  # runc >=1.5 enables the libpathrs cgo binding (cyphar.com/go-pathrs) by
+  # default, which needs the native libpathrs C library we don't package.
+  # Opt out so runc uses its pure-Go pathrs-lite fallback for this static build.
+  export RUNC_BUILDTAGS="-libpathrs"
   make static
   cp runc "${GOBIN}/runc"
 popd


### PR DESCRIPTION
runc >=1.5 changed its upstream Makefile default BUILDTAGS to include "libpathrs", which arrived here via a routine guardian dependency bump (not a deliberate choice on our side). That tag links runc against the native libpathrs shared library via CGO and pulls in cyphar.com/go-pathrs, breaking our BOSH compile with "cannot find module providing package cyphar.com/go-pathrs (import lookup disabled by -mod=vendor)".

Opt out with RUNC_BUILDTAGS="-libpathrs" before `make static`.

Why not use libpathrs:
- runc's safe path-resolution has two implementations selected by the build tag: the native libpathrs CGO shim (*_libpathrs.go) and a pure-Go fallback (*_purego.go, //go:build !libpathrs). Dropping the tag keeps the hardening via the pure-Go pathrs-lite path -- it is not a security regression, and it matches runc's behaviour in every prior release here.
- This package builds fully static (-buildmode=pie -extldflags -static-pie, netgo osusergo). libpathrs is a CGO/dynamic dependency that fights static linking.
- We do not package the native libpathrs library, and adopting it would mean adding+patching a new BOSH package dependency and giving up static linking -- a deliberate, scoped project, not a build-flag flip.
- Upstream provides RUNC_BUILDTAGS="-libpathrs" precisely for static/distro builders in our situation.

Caveat: native libpathrs is upstream's preferred implementation and may get hardening/feature work ahead of pathrs-lite; revisit if a future CVE or feature lands only in the native library.

ai-assisted=yes

- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->


Backward Compatibility
---------------
Breaking Change? **Yes/No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
